### PR TITLE
docs(todo): TRIM bookkeeping — mark TRIM-007 Done

### DIFF
--- a/docs/todos/TRIM-dto-trimming-preservation-gaps/todo.md
+++ b/docs/todos/TRIM-dto-trimming-preservation-gaps/todo.md
@@ -44,11 +44,11 @@ A third suspected gap turned out to be already fixed: event records derive `Fact
 | 001 | Done | [Positional-record preservation in factory signatures](./plans/001-positional-record-signature-preservation.md) | `DtoTypeWalker.WalkFactoryReturn` `HasParameterlessCtor` gate; zTreatment cut-over `StartVisitResultV2` hotfix |
 | 002 | Done | [`[Factory]` entity property-graph DTO discovery](./plans/002-factory-entity-property-dto-discovery.md) | `WalkFactoryReturn` bails on `[Factory]` roots without descending; zTreatment `TreatmentBanner` / `DashboardContactResult` hotfixes |
 | 003 | Done | [Verify event-record preservation needs no consumer entries](./plans/003-verify-event-record-preservation.md) | `FactoryEventBase` DAM annotation shipped v1.4.0; consumer entries predate it, never re-tested — **verification came back RED**, re-split → TRIM-007 |
-| 007 | Draft | [Subscribe-only event preservation fix](./plans/007-subscribe-only-event-preservation-fix.md) | TRIM-003 finding: inherited DAM doesn't flow to derived types under ILLink; ctor stripped in the subscribe-only shape; fix mechanism keyboard-validated |
+| 007 | Done | [Subscribe-only event preservation fix](./plans/007-subscribe-only-event-preservation-fix.md) | TRIM-003 finding: inherited DAM doesn't flow to derived types under ILLink; fixed via generator-emitted per-assembly event-preservation registrar |
 | 005 | Draft | [Server-only reference over-retention in trimmed clients](./plans/005-server-only-reference-over-retention.md) | TRIM-004 discovery: guarded-dead `LocalCreate` bodies retain server-only interface refs, contradicting `docs/trimming.md` |
 | 006 | Draft | [Incremental-generator caching regression test](./plans/006-incremental-cache-regression-test.md) | TRIM-001 gate: no test asserts cached pipeline steps — non-EquatableArray transform fields regress silently (plan review B1) |
 
-Execution order: 004 → 001 → 002 → 003 → 007 → 005 → 006 (rows listed in execution order; numbering stays monotonic by creation). Branching: todo/plan docs commit on the `TRIM` branch; each plan's implementation gets its own branch off `TRIM`. Note: TRIM-003's branch (`TRIM-003-verify-event-preservation`) carries the intentionally red harness check and stays unmerged until TRIM-007 turns it green.
+Execution order: 004 → 001 → 002 → 003 → 007 → 005 → 006 (rows listed in execution order; numbering stays monotonic by creation). Branching: todo/plan docs commit on the `TRIM` branch; each plan's implementation gets its own branch off `TRIM`. (TRIM-003's red verification and TRIM-007's fix merged together via PR #71.)
 
 ## Skipped Steps
 
@@ -85,6 +85,11 @@ Execution order: 004 → 001 → 002 → 003 → 007 → 005 → 006 (rows liste
 - **Decision:** Amend.
 - **Index changes:** add TRIM-006 (incremental-cache regression test — pre-existing tech debt, plan review B1), executed last.
 - **Follow-up:** TRIM-006.
+
+### 2026-07-13 — TRIM-007 (gates cleared, merged)
+- **Finding:** Generator-emission fix landed (PR #71, CI green first run): fourth pipeline branch + per-assembly `NeatooEventPreservationRegistrar`; TRIM-003's red check green in the pure consumer shape incl. nested record. Plan review's veto (accessibility gate — the repo's own private nested test events would have broken every consumer build) folded pre-implementation. Test gate cleared (10 unit tests incl. determinism + FQN-decoy guards). Code review caught 3 veto doc findings — the falsified DAM claim surviving in `FactoryEventRelayPattern.cs`, `docs/factory-events.md`, and the smoke test's own summary — all fixed, plus skill-reference and IL2026-justification callouts. Reviews: `reviews/007-*.md`.
+- **Decision:** Amend.
+- **Follow-up:** n/a — remaining queue: TRIM-005, TRIM-006, then todo-level release step (AC4 release notes deferred there).
 
 ### 2026-07-07 — TRIM-003 (verification RED, re-split → TRIM-007)
 - **Finding:** The subscribe-only consumer shape FAILS on a trimmed client: the event type survives (generic instantiation + runtime `[FactoryEvent]` scan) but its ctor is stripped — inherited `[DynamicallyAccessedMembers]` on `FactoryEventBase` does not flow to derived types under ILLink (DAM is `AttributeUsage(Inherited = false)`; the docs' "Inherited = true" story is runtime-reflection semantics). The todo's "third gap already fixed" premise was wrong; zTreatment's event LinkerConfig entries are load-bearing. Triplet evidence: red trimmed / green untrimmed / green trimmed with DAM on `Subscribe<TEvent>` (fix mechanism validated — the `Raise<T>` producer-side pattern). Long form: TRIM-003 Amendment 1.


### PR DESCRIPTION
## Summary

Bookkeeping commit marking TRIM-007 Done after PR #71 merged. This PR itself is one docs file — the code shipped through PRs #68–#71 — but it's a good vantage point for the **cumulative TRIM impact** since the todo began:

**Full diff:** https://github.com/NeatooDotNet/RemoteFactory/compare/2275e79...TRIM — 59 files, +3,141 / −218

| Category | Files | Lines |
|----------|-------|-------|
| Production (Generator + RemoteFactory) | 14 | +432 / −103 |
| Tests + trimming harness | 15 | +1,554 / −48 |
| Docs, Design source of truth, skill refs | 9 | +78 / −67 |
| Todo container (plans, reviews, discovery log) | 19 | +1,038 |
| CI + solution | 2 | +39 |

## What that bought (PRs #68–#71)

- **#68 TRIM-004** — the trimming harness became an enforceable CI gate (was: outside the sln, exit-0 on failure, hadn't compiled since v1.5.0)
- **#69 TRIM-001** — positional records in factory signatures preserved (`PreserveType<T>` bucket) — the `StartVisitResultV2` failure class
- **#70 TRIM-002** — DTOs carried as `[Factory]` entity properties discovered via per-entity self-walk — the `TreatmentBanner`/`DashboardContactResult` failure class — plus the `Systems.*` namespace hardening
- **#71 TRIM-003+007** — proved inherited DAM does *not* preserve event-record descendants under ILLink, then fixed it with the generator-emitted per-assembly event-preservation registrar (subscribe-only events + their nested graphs now automatic)

Remaining queue: TRIM-005 (server-only over-retention), TRIM-006 (incremental-cache regression test), then the release step (AC4/AC5 — the version zTreatment PCB-003 consumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)