### PR TITLE
PHASE-001: DispatchPhase model, registry phase, dispatcher queueing

### DIFF
--- a/docs/todos/PHASE-phased-event-dispatch/plans/001-phase-model-and-queueing.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/001-phase-model-and-queueing.md
@@ -3,7 +3,7 @@
 **Plan #:** 001
 **Date:** 2026-08-14
 **Related Todo:** [../todo.md](../todo.md)
-**Status:** Draft
+**Status:** Done
 **Last Updated:** 2026-08-14
 **Plan-review opt-in:** Yes (public API: new enum, attribute constructor, registry signature — hard to change after release)
 **Code-review opt-in:** Yes (changes the core dispatch path every event flows through)
@@ -128,6 +128,11 @@ the consumer-facing coordinator is PHASE-004), and does not change relay or seri
 - [ ] An event raised by a handler *during* a drain, whose handlers land in the draining
       or an already-passed phase, is processed in the same drain (drain-until-empty —
       nothing is silently dropped). `[unit]`
+- [ ] A drain also sweeps up any earlier phase the consumer never drained, earliest phase
+      first, under the drain point's failure semantics — the fail-open behavior PHASE-004
+      builds its warning on. Later phases than the one requested are left alone. `[unit]`
+- [ ] A queued dispatch reaches its handler with the event instance, `RaiseOptions`, and
+      originating scope provider it was queued with. `[unit]`
 - [ ] Two scopes' queues are independent; a scope disposed without draining runs nothing
       (rollback-discard). *(Same interim annotation as bullet 2.)* `[unit]`
 - [ ] A phase-registered event raised without `ServerOnly` is still collected for the
@@ -175,13 +180,76 @@ Walked 2026-08-14 against v1.7.0 (`main` @ 94a8a12):
 
 ## Test Evidence
 
-*(Filled after implementation, before the Step 5 gate.)*
+All cited tests live in `src/Tests/RemoteFactory.UnitTests/Internal/`; namespace prefix
+`RemoteFactory.UnitTests.Internal` omitted below for width.
+
+| Acceptance bullet (short) | Tier declared | Test method | Tier confirmed |
+|---|---|---|---|
+| Phase-less handler keeps today's contract | `[explicit-skip]` | No existing test modified (`git status src/Tests` shows only new files). Suite: 653 unit × net9.0/net10.0 (0 failures) against a 614 baseline on `main` — +39 new cases, all added by this plan; integration 561 passed / 5 skipped / 566 total × 2 (`reviews/001-test.log`); Design 86 × 2, 0 failures (`reviews/001-test-design.log`) | ✓ |
+| AfterCommit handler not invoked at raise time | `[unit]` | `FactoryEventsDispatcherPhaseTests.Raise_DeferredHandler_DoesNotDispatchAtRaiseTime`; primitive-level: `FactoryEventPhaseSchedulerTests.Enqueue_DoesNotInvokeHandler` | ✓ |
+| Mixed phases: Immediate runs, other queues | `[unit]` | `FactoryEventsDispatcherPhaseTests.Raise_MixedPhases_ImmediateRunsAndDeferredWaits` (also pins cross-phase ordering) | ✓ |
+| Post-completion drain: FIFO, logged+swallowed, rest still run, OCE propagates | `[unit]` | `FactoryEventPhaseSchedulerTests.DrainAsync_RunsDeferredDispatchesInFifoOrder`, `.DrainAsync_PostCompletion_SwallowsHandlerExceptionAndRunsTheRest`, `.DrainAsync_PostCompletion_StillPropagatesCancellation`, and for the log half `.DrainAsync_PostCompletionSwallow_LogsTheDedicatedEventIdWithTheException` (asserts event id 9003 + attached exception) | ✓ |
+| Drain sweeps earlier phases the consumer never drained | `[unit]` | `FactoryEventPhaseSchedulerTests.DrainAsync_SweepsAnEarlierPhaseTheConsumerNeverDrained` (also asserts 9003 attributes the failure to the *queued* phase), `.DrainAsync_MidDrainEarlierPhaseWork_PreemptsRemainingLaterPhaseWork` (pins the ordering choice), `.DrainAsync_DoesNotRunLaterPhasesThanRequested` — **all three verified red** against the pre-fix drain (`reviews/001-redproof.log`) | ✓ |
+| Queued dispatch carries its event, options, and provider intact | `[unit]` | `FactoryEventPhaseSchedulerTests.DrainAsync_HandlerReceivesTheEventAndOptionsItWasQueuedWith` (asserts `Assert.Same` on the originating scope provider, not merely non-null) | ✓ |
+| In-transaction drain propagates; same handlers swallow at post-completion point | `[unit]` | `FactoryEventPhaseSchedulerTests.DrainAsync_InTransaction_PropagatesHandlerExceptionAndAbortsRemaining`, `.DrainAsync_SamePhaseHandlersDrainPoint_KeysSemanticsNotThePhase` | ✓ |
+| Re-entrant enqueue during drain runs in same drain (same phase AND already-passed phase) | `[unit]` | `FactoryEventPhaseSchedulerTests.DrainAsync_ReentrantEnqueueDuringDrain_RunsInTheSameDrain` (same phase), `.DrainAsync_ReentrantEnqueueIntoAnAlreadyPassedPhase_StillRunsInThisDrain` (already-passed — **verified red against the pre-fix single-queue drain**), `.DrainAsync_DoesNotRunLaterPhasesThanRequested` (bounds it); real raise-path re-entrancy: `FactoryEventsDispatcherPhaseTests.DrainedHandlerRaisingAnEvent_GoesThroughTheRealRaisePath` | ✓ |
+| Scope independence; never-drained runs nothing | `[unit]` | `FactoryEventPhaseRegistrationTests.PhaseDispatcher_IsScoped_NotSharedAcrossScopes`, `FactoryEventPhaseSchedulerTests.ScopeDisposedWithoutDraining_RunsNothing` (real scope, disposed) | ✓ |
+| Phase-registered event still collected for relay | `[unit]` | `FactoryEventsDispatcherPhaseTests.Raise_DeferredHandler_StillCollectsForRelayAtRaiseTime` (Server-mode container, per review B-C3); `ServerOnly` counterpart: `.Raise_DeferredHandlerWithServerOnly_IsNotCollectedForRelay` | ✓ |
+| Registry dedupe holds; first-registration-wins documented | `[unit]` | `FactoryEventPhaseRegistrationTests.RegisterHandler_RepeatedContainerBuilds_DedupesByEventAndHandlerClass`, `.RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration` | ✓ |
+| Build/test green | `[explicit-skip]` | `reviews/001-build.log` (0 errors, net9.0+net10.0), `reviews/001-test.log` (0 failures) | ✓ |
+
+Additional coverage not tied to a single bullet: `RegisterHandler_WithoutPhase_DefaultsToImmediate`,
+`RegisterHandler_WithPhase_RoundTripsThePhase`, `PhaseDispatcher_RegisteredInModesThatDispatchHandlers`
+(Theory: Server + Logical), `PhaseDispatcher_NotRegisteredInRemoteMode`,
+`DrainAsync_OnlyDrainsTheRequestedPhase`, `DrainAsync_NothingDeferred_IsANoOp`,
+`DrainAsync_DeferredDispatchesRunOnce_NotOnASecondDrain`,
+`Attribute_NoArgument_DefaultsToImmediate`, `Attribute_ExplicitPhase_RoundTrips` (Theory: all
+three phases), `RaiseUntyped_DeferredHandler_DefersJustLikeRaise`,
+`Raise_PhasedHandlerWithNoQueueInScope_DispatchesImmediatelyRatherThanVanishing`,
+`DrainAsync_HandlerReceivesTheDrainTimeCancellationToken` (pins the drain-time token choice
+PHASE-003 will reason from), `Enqueue_NullEvent_Throws`.
+
+**Deliberately not covered here** (drain *points* are PHASE-003/004's deliverable, so no
+integration-tier coverage of real factory calls belongs to this plan): entry-call tracking,
+the consumer coordinator, and the same-response relay-batch guarantee.
 
 ---
 
 ## Plan Amendments
 
-*(none yet)*
+### 2026-08-14 — Handler attribute moved out of the generator-linked source file
+
+- **Section affected:** Step 1
+- **Original said:** add the optional phase argument to `[FactoryEventHandler<T>]` in place.
+- **What changed:** the attribute moved to its own `FactoryEventHandlerAttribute.cs`.
+- **Why:** `FactoryAttributes.cs` is `<Compile Include>`-linked into the netstandard2.0
+  Generator project, so referencing `DispatchPhase` from it compiled the enum into
+  `Neatoo.Generator.dll`, duplicating a public runtime type (CS0436/CS0433 in every project
+  referencing both). The generator matches the attribute by metadata-name string and never
+  needed the type.
+- **Discovery Log link:** 2026-08-14 — PHASE-001 (shared-source build constraint)
+
+### 2026-08-14 — Drain sweeps earlier phases, not just the requested one
+
+- **Section affected:** Step 5, Constraints (re-entrant enqueue)
+- **Original said:** drain-until-empty within the phase being drained.
+- **What changed:** `DrainAsync` drains the requested phase *and every earlier phase*,
+  earliest first, until none remain.
+- **Why:** the test-review gate found the original shape silently dropped work enqueued
+  into an already-passed phase — and, separately, would have lost `AfterFlush` handlers
+  entirely for any consumer who never called the coordinator. That fail-open behavior is
+  PHASE-004's AC-5, now structurally satisfied here.
+- **Discovery Log link:** 2026-08-14 — PHASE-001 (gate found a real defect)
+
+### 2026-08-14 — Scheduler naming
+
+- **Section affected:** Step 5
+- **Original said:** the drain primitive as `IFactoryEventPhaseDispatcher`.
+- **What changed:** renamed to `IFactoryEventPhaseScheduler` / `FactoryEventPhaseScheduler`.
+- **Why:** code review C1 — two "…Dispatcher" types in one assembly doing different jobs,
+  settled before PHASE-003 emits generated call sites against the name. `…Queue` was
+  unavailable: CA1711 forbids the suffix.
+- **Discovery Log link:** see [reviews/001-code-review.md](../reviews/001-code-review.md)
 
 ---
 

--- a/docs/todos/PHASE-phased-event-dispatch/plans/003-aftercommit-entry-call-drain.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/003-aftercommit-entry-call-drain.md
@@ -26,4 +26,23 @@ directly, bypassing public wrappers. This plan does NOT own the consumer-facing 
 
 ---
 
-*(Stub — Intent, Alignment, Constraints, Steps, Acceptance filled at Step 2.)*
+## Constraints inherited from PHASE-001 (recorded at its Step 5 gate)
+
+- **The drain call sits on the success path only** — never in a `finally`, never in a
+  scope-disposal hook or middleware that runs on failure. Rollback-discard is emergent
+  ("a scope that fails simply never drains"), so a drain on the failure path breaks the
+  todo's AC-2 silently and no primitive-level test can catch it (code review C4).
+- The scheduler API to call is `IFactoryEventPhaseScheduler.DrainAsync(phase,
+  inTransaction, ct)` in `Neatoo.RemoteFactory.Internal` — public so generated code can
+  reach it. Pass `inTransaction: false` at the entry-call drain point.
+- The cancellation-token *policy* question is open here: queued dispatches currently
+  receive the drain-time token (pinned by
+  `FactoryEventPhaseSchedulerTests.DrainAsync_HandlerReceivesTheDrainTimeCancellationToken`).
+  Decide whether a post-completion drain should pass the request token at all — an
+  `OperationCanceledException` from it fails a call that already succeeded (plan review
+  B-C5).
+- `IFactoryEvents.RaiseUntyped` has no general test coverage repo-wide; it is the
+  server-side landing point for client-raised events, so this plan's remote-entry work is
+  the natural place to add it (tech debt raised at PHASE-001's gate).
+
+*(Stub — Intent, Alignment, remaining Constraints, Steps, Acceptance filled at Step 2.)*

--- a/docs/todos/PHASE-phased-event-dispatch/plans/004-afterflush-coordinator.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/004-afterflush-coordinator.md
@@ -22,4 +22,17 @@ coordinator is a drain trigger, nothing more.
 
 ---
 
-*(Stub — Intent, Alignment, Constraints, Steps, Acceptance filled at Step 2.)*
+## Inherited from PHASE-001 (recorded at its Step 5 gate)
+
+- **The fail-open sweep is already implemented and test-pinned.** `DrainAsync(phase, …)`
+  drains the requested phase *and every earlier one*, earliest first, so `AfterFlush`
+  handlers a consumer never drained are swept up at the `AfterCommit` point under that
+  drain point's swallow semantics (`FactoryEventPhaseSchedulerTests.DrainAsync_SweepsAnEarlierPhaseTheConsumerNeverDrained`).
+  What is missing is only the **logged warning** the todo's AC-5 requires — and the
+  discriminator is already plumbed: `TryDequeueThrough` returns the phase each dispatch was
+  queued at (code review C3). Wire the warning; do not re-plumb the sweep.
+- `IFactoryEventPhaseCoordinator.DrainAsync(AfterFlush)` should call through to the
+  scheduler with `inTransaction: true` so handler exceptions propagate and the consumer's
+  transaction can still roll back.
+
+*(Stub — Intent, Alignment, remaining Constraints, Steps, Acceptance filled at Step 2.)*

--- a/docs/todos/PHASE-phased-event-dispatch/reviews/001-code-review.md
+++ b/docs/todos/PHASE-phased-event-dispatch/reviews/001-code-review.md
@@ -1,0 +1,66 @@
+# PHASE-001 Code Review — 2026-08-14
+
+**Reviewer:** code-reviewer agent (findings-only, no grade)
+**Disposition:** all four veto-tier findings fixed; callouts fixed, traced forward, or
+accepted with reason below.
+
+## Verified clean by the reviewer
+
+- **Trimming invariant holds.** `[DynamicallyAccessedMembers(All)]` is present on `TEvent`
+  for *both* `RegisterHandler` overloads, and the 2-arg forwards into the annotated 3-arg
+  parameter so the annotation flows rather than being dropped at the hop.
+- **No reflection introduced.** The only `GetType()` calls are `.Name` for log messages.
+- **Backward compatibility is structural:** zero modified test files; the generator's
+  emitted 2-arg `RegisterHandler` call and the checked-in generated output still compile.
+- **The `TryDequeueThrough` LINQ-over-dictionary pattern is safe:** `OrderBy` buffers its
+  source on first `MoveNext`, and the loop returns synchronously before any `await`, so the
+  only mutation that can add a key (`Enqueue`, reachable only from inside a handler) happens
+  after enumeration has finished.
+- **Scoping split is right:** process-static registry keeps its locking; the per-scope
+  scheduler is unsynchronized, matching the established `FactoryEventCollector` stance.
+- **The build-config move is correct:** the generator matches the handler attribute by
+  metadata-name string in both places it looks, so it never needed the type.
+
+## Veto-tier findings — all fixed
+
+- **V1 — `CLAUDE-DESIGN.md` log-id table not updated.** Added rows for 9001/9002/9003 (and
+  9004, added in this same pass) with propagation semantics reflecting the drain-point
+  keying.
+- **V2 — no test-review record.** The gate had in fact run; the record is now written to
+  [`001-test-review.md`](./001-test-review.md), including a second round.
+- **V3 — Test Evidence cited numbers the log contradicted.** Corrected to the actual
+  figures: 653 unit × 2 TFMs against a 614 baseline on `main`, integration 561 passed /
+  5 skipped / 566 total, Design 86 × 2 with its own retained log.
+- **V4 — `DispatchPhase` XML doc asserted an ordering guarantee the drain-until-empty
+  stance breaks.** Added the carve-out sentence naming the re-entrant case, and rewrote the
+  `DrainAsync` doc (which the test reviewer independently flagged as stale).
+
+## Callout dispositions
+
+- **C1 (naming collision)** — fixed by renaming to `IFactoryEventPhaseScheduler` /
+  `FactoryEventPhaseScheduler`, settled *before* PHASE-003 emits generated call sites.
+  (`…Queue` was not available: CA1711 forbids the suffix, which is what produced the
+  original `Dispatcher` name.)
+- **C2 (silent phase→Immediate fallback)** — fixed: new debug event id 9004 fires when a
+  phased handler is raised in a scope with no scheduler, matching the todo's house rule of
+  "dispatch immediately with a debug log, no silent drop."
+- **C3 (fail-open discriminator already plumbed)** — recorded as a constraint on the
+  PHASE-004 draft; the sweep is now also test-pinned, so 004 wires a warning rather than
+  re-plumbing.
+- **C4 (no discard affordance)** — recorded as a hard constraint on the PHASE-003 draft:
+  the drain call must sit on the success path only, never in a `finally`.
+- **C5 (near-tautological provider assertion)** — fixed: `Assert.Same` against the
+  originating scope provider.
+- **C6 (evidence claims without artifacts)** — fixed: `001-redproof.log` and
+  `001-test-design.log` retained in `reviews/`.
+- **C9 (handler not null-guarded)** — fixed.
+- **C11 (LoggerMessage parameter order)** — fixed for 9002/9003 to match the repo's
+  template-order convention.
+- **C7 (per-item LINQ re-derivation)** — accepted. ≤3 phases makes the cost nil, and the
+  safety argument is documented in the method's comment. Pre-seeding the dictionary is a
+  reasonable future hardening but changes `HasPending`'s shape.
+- **C8 (single-logical-flow assumption undocumented)** — accepted with a note: the
+  assumption matches the pre-existing `FactoryEventCollector` stance. Worth a sentence on
+  the interface if PHASE-003 finds a concurrent-raise scenario.
+- **C10 (`NeatooLoggerCategories.Server` in Logical mode)** — accepted; the existing
+  category set has no better fit and inventing one is out of this plan's scope.

--- a/docs/todos/PHASE-phased-event-dispatch/reviews/001-test-review.md
+++ b/docs/todos/PHASE-phased-event-dispatch/reviews/001-test-review.md
@@ -1,0 +1,73 @@
+# PHASE-001 Test Review — 2026-08-14
+
+**Reviewer:** test-reviewer agent (two rounds)
+**Closing tier:** must-cover closed; all round-1 should-cover closed; round-2 should-cover
+closed. Remaining nice-to-have accepted or queued as tech debt.
+
+## Round 1 — findings and dispositions
+
+**must-cover (all closed):**
+
+1. **Re-entrant enqueue into an already-passed phase was untested — and was a real
+   production defect.** `DrainAsync` resolved exactly one queue, so a handler enqueueing
+   into a phase whose drain point had passed was silently dropped. Fixed by
+   `TryDequeueThrough`, which takes the next dispatch from the earliest non-empty phase at
+   or before the requested one, looping until all are empty. Pinned by
+   `DrainAsync_ReentrantEnqueueIntoAnAlreadyPassedPhase_StillRunsInThisDrain`.
+2. **The 9xxx logging path never executed in any test** (the test helper left the optional
+   `ILoggerFactory` null). `NewDispatcher` now wires a capturing provider;
+   `DrainAsync_PostCompletionSwallow_LogsTheDedicatedEventIdWithTheException` asserts id
+   9003, `LogLevel.Error`, and the exact exception instance.
+3. **Queued-dispatch payload fidelity unasserted.**
+   `DrainAsync_HandlerReceivesTheEventAndOptionsItWasQueuedWith` asserts the exact
+   (event value, `RaiseOptions`) pairs and — after code-review C5 — `Assert.Same` on the
+   originating scope provider.
+
+**should-cover (all closed):** real scope-disposal rollback-discard test replacing the
+vacuous `NeverDrained_RunsNothing`; `RaiseUntyped` parity; drain-time cancellation-token
+plumbing; attribute default/explicit phase round-trip; the no-queue fallback tested rather
+than deleted; re-entrancy exercised through the real `handler → IFactoryEvents.Raise →
+registry → defer` path.
+
+## Round 2 — findings and dispositions
+
+**must-cover (closed):** the multi-phase drain fix introduced a *new* untested behavior —
+a later-phase drain now also sweeps an earlier phase the consumer never drained (PHASE-004's
+fail-open path, implemented here as a side effect). Closed by
+`DrainAsync_SweepsAnEarlierPhaseTheConsumerNeverDrained`, which also asserts 9003
+attributes the failure to the phase the dispatch was *queued* at rather than the phase
+requested.
+
+**should-cover (closed):** mid-drain earlier-phase work preempts remaining later-phase work
+— pinned deliberately by `DrainAsync_MidDrainEarlierPhaseWork_PreemptsRemainingLaterPhaseWork`
+so the ordering is a decision, not an accident; and the stale `DrainAsync` XML doc, rewritten
+to state that the drain covers the requested phase and every earlier one.
+
+**nice-to-have (accepted, not actioned):** `Raise_DeferredHandler_StillCollectsForRelayAtRaiseTime`
+does not also assert `HasPending` (reviewer confirmed not must-fix — the premise is
+independently pinned); 9002's count spans phases while its `{Phase}` names only the
+requested one; `DrainAsync_OnlyDrainsTheRequestedPhase` is now a mild misnomer;
+`Enqueue(DispatchPhase.Immediate, ...)` remains unspecified on the interface.
+
+## Red-verification
+
+Per the project memory *"a check that could never go red is not evidence"*, the three
+multi-phase drain tests were run against the pre-fix implementation (`p <= through`
+reverted to `p == through`). All three failed; log retained at
+[`001-redproof.log`](./001-redproof.log). The fix was then restored and the full suite
+re-run green.
+
+## Tech debt queued (not absorbed into this plan)
+
+- `IFactoryEvents.RaiseUntyped` has no general coverage anywhere in the repo — pairs
+  naturally with PHASE-003's remote-entry work.
+- `FactoryEventHandlerRegistry` is process-global mutable static with no test-isolation
+  hook (`Clear()` is internal and uncalled), forcing every test to invent unique event
+  types.
+
+Both are recorded as Plan Index entries in the parent todo.
+
+## Final state
+
+Build 0 errors; unit 653 × net9.0/net10.0, integration 561 passed / 5 skipped × 2, Design
+86 × 2 — all 0 failures. No existing test modified.

--- a/docs/todos/PHASE-phased-event-dispatch/todo.md
+++ b/docs/todos/PHASE-phased-event-dispatch/todo.md
@@ -127,7 +127,13 @@ exposes drain points.
 
 ## Sibling Todos
 
-*(none)*
+- [ ] [RFEF — RemoteFactory.EntityFrameworkCore, declarative factory transactions](../RFEF-factory-transactions/todo.md)
+  — surfaced 2026-08-14 while discussing this todo's target consumer code (per-method
+  begin/commit boilerplate); doesn't advance PHASE's goal (persistence stays out of this
+  framework arc) but builds directly on PHASE-003's entry-call tracking and PHASE-004's
+  drain semantics, and would generate the `AfterFlush` drain call PHASE-004 otherwise
+  leaves to consumer code. Blocked until those plans land. (Link resolves once the RFEF
+  branch merges to main.)
 
 ---
 

--- a/docs/todos/PHASE-phased-event-dispatch/todo.md
+++ b/docs/todos/PHASE-phased-event-dispatch/todo.md
@@ -70,16 +70,36 @@ exposes drain points.
 
 | # | File | Title | Status |
 |---|------|-------|--------|
-| 001 | [001-phase-model-and-queueing](./plans/001-phase-model-and-queueing.md) | DispatchPhase enum, registry phase, dispatcher queueing | Draft |
+| 001 | [001-phase-model-and-queueing](./plans/001-phase-model-and-queueing.md) | DispatchPhase enum, registry phase, dispatcher queueing | Done |
 | 002 | [002-generator-phase-passthrough](./plans/002-generator-phase-passthrough.md) | Generator reads phase from attribute, threads to registration | Draft |
 | 003 | [003-aftercommit-entry-call-drain](./plans/003-aftercommit-entry-call-drain.md) | Entry-call tracking in generated factories; AfterCommit drain | Draft |
 | 004 | [004-afterflush-coordinator](./plans/004-afterflush-coordinator.md) | IFactoryEventPhaseCoordinator public API + fallback drain | Draft |
 | 005 | [005-design-docs-skill](./plans/005-design-docs-skill.md) | Design projects, published docs, skill reference | Draft |
 | 006 | [006-coalescing](./plans/006-coalescing.md) | Opt-in same-event coalescing (v2, queued per user) | Draft |
+| 007 | *(not yet drafted)* | Tech debt: registry test-isolation hook (`Clear()` is internal and uncalled; every test invents unique event types) | Draft |
 
 ---
 
 ## Discovery Log
+
+### 2026-08-14 — PHASE-001 (gate found a real defect)
+- **Finding:** The test-review gate caught that the drain resolved only the requested
+  phase's queue, so work a handler enqueued into an already-passed phase was silently
+  dropped — the exact silent-loss class this todo exists to remove.
+- **Decision:** Amend — replaced with a drain that sweeps the requested phase and every
+  earlier one, earliest first; three tests verified red against the pre-fix code.
+- **Follow-up:** PHASE-004 inherits the sweep (it implements that plan's fail-open path);
+  constraint recorded in its draft. See [reviews/001-test-review.md](./reviews/001-test-review.md).
+
+### 2026-08-14 — PHASE-001 (shared-source build constraint)
+- **Finding:** `FactoryAttributes.cs` is linked into the netstandard2.0 Generator project,
+  so putting `DispatchPhase` on the handler attribute compiled the enum into
+  `Neatoo.Generator.dll` too — duplicating a public runtime type and breaking every
+  project referencing both (CS0436 in RemoteFactory, CS0433 in UnitTests).
+- **Decision:** Amend — moved `FactoryEventHandlerAttribute<T>` to its own unlinked file;
+  the generator matches it by metadata-name string and never needed the type.
+- **Follow-up:** n/a (PHASE-002 must not re-link `DispatchPhase` into the generator; the
+  new file's XML doc carries the warning).
 
 ### 2026-08-14 — PHASE-001 (plan review)
 - **Finding:** Plan review returned CONCERNS — 4 veto findings, the sharpest being that

--- a/src/Design/CLAUDE-DESIGN.md
+++ b/src/Design/CLAUDE-DESIGN.md
@@ -1014,6 +1014,10 @@ These are known limitations or open questions. They are documented here to preve
 | 3009 | `FactoryEventDeserializationFailed` | Error | Wire-format event deserialization fails (e.g. `UnknownFactoryEventTypeException`) | Swallowed; `Relay` is NOT invoked for that call (the one legitimate case of zero `Relay` invocations for a [Remote] call) |
 | 3011 | `NoOpFactoryEventRelayFirstEvent` | Warning | `NoOpFactoryEventRelay` receives its first non-empty batch (consumer forgot to register a relay) | Informational; fires once per process |
 | 3012 | `FactoryEventTypeRegistryCollision` | Warning | `FactoryEventTypeRegistry` assembly scan finds two distinct `Type`s sharing the same `FullName` | Documents kept/dropped assembly; wire messages resolve to the kept type |
+| 9001 | `FactoryEventPhaseQueued` | Debug | A handler registered at a non-`Immediate` `DispatchPhase` is deferred instead of dispatched at `Raise` time | Informational |
+| 9002 | `FactoryEventPhaseDrained` | Debug | A phase drain completes, reporting how many dispatches ran through the requested phase (earlier phases included) | Informational |
+| 9003 | `FactoryEventPhaseHandlerFailed` | Error | A deferred handler throws during a **post-completion** drain (no ambient transaction) | Swallowed — the exception can no longer roll anything back; remaining queued handlers still run. `OperationCanceledException` still propagates. In-transaction drains propagate instead, so this never fires for them. |
+| 9004 | `FactoryEventPhaseNoQueueInScope` | Debug | An event with a phased handler is raised in a scope with no `IFactoryEventPhaseScheduler` registered | Dispatched immediately rather than dropped |
 
 ### Public Exception
 

--- a/src/RemoteFactory/AddRemoteFactoryServices.cs
+++ b/src/RemoteFactory/AddRemoteFactoryServices.cs
@@ -77,6 +77,13 @@ public static partial class RemoteFactoryServices
 		{
 			services.TryAddScoped<IFactoryEvents, FactoryEventsDispatcher>();
 
+			// Per-scope queue for handlers registered at a non-Immediate DispatchPhase.
+			// Registered for Server AND Logical — unlike IFactoryEventCollector, which is
+			// about relaying to a client and is therefore Server-only. Handler dispatch
+			// happens in both modes, so both need somewhere to queue.
+			services.TryAddScoped<IFactoryEventPhaseScheduler>(sp =>
+				new FactoryEventPhaseScheduler(sp, sp.GetService<ILoggerFactory>()));
+
 			// Register the delegate handler for remote IFactoryEvents.Raise requests.
 			// When a Remote client sends a RaiseFactoryEventRemote request, the server
 			// resolves this delegate, dispatches to local handlers in the request scope,

--- a/src/RemoteFactory/DispatchPhase.cs
+++ b/src/RemoteFactory/DispatchPhase.cs
@@ -1,0 +1,65 @@
+namespace Neatoo.RemoteFactory;
+
+/// <summary>
+/// Declares <i>when</i> a <c>[FactoryEventHandler&lt;T&gt;]</c> handler runs relative to the
+/// factory operation that raised the event.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Immediate"/> handlers dispatch at <see cref="IFactoryEvents.Raise{T}"/> time,
+/// inside whatever transaction the caller has open, observing the caller's staged
+/// (unflushed) state. <see cref="AfterFlush"/> and <see cref="AfterCommit"/> handlers are
+/// queued per DI scope at raise time and drained later; if the factory operation fails,
+/// the queues are discarded and the handlers never run.
+/// </para>
+/// <para>
+/// Cross-phase ordering is guaranteed: for one factory operation, all
+/// <see cref="Immediate"/> handlers complete before any <see cref="AfterFlush"/> handler
+/// runs, and all <see cref="AfterFlush"/> handlers complete before any
+/// <see cref="AfterCommit"/> handler runs. Order <i>within</i> a phase is unspecified.
+/// </para>
+/// <para>
+/// One carve-out: a handler running in a drain can itself raise an event whose handlers
+/// belong to a phase whose drain point has already passed. That work runs in the current
+/// drain — before any dispatch still queued for later phases — rather than being dropped.
+/// So a handler for an earlier phase can observe a later phase's handler having already
+/// run, when the earlier-phase work was created by that later-phase handler.
+/// </para>
+/// <para>
+/// RemoteFactory owns no persistence concepts — it never flushes or commits. The phase
+/// names describe consumer intent at the drain points the framework exposes.
+/// </para>
+/// </remarks>
+public enum DispatchPhase
+{
+    /// <summary>
+    /// Today's contract and the default: dispatched synchronously at
+    /// <see cref="IFactoryEvents.Raise{T}"/> time in the caller's DI scope, sequential and
+    /// awaited, mid-transaction with the caller's writes still staged. A handler exception
+    /// aborts the remaining handlers and propagates so the caller's transaction can roll
+    /// back. The right phase for handlers that must be atomic with the save.
+    /// </summary>
+    Immediate = 0,
+
+    /// <summary>
+    /// Queued at raise time; drained when the consumer signals — typically between the
+    /// outermost flush and the commit, via
+    /// <c>IFactoryEventPhaseCoordinator.DrainAsync</c>. Handlers run in-transaction but
+    /// see flushed state; an exception propagates to the drain caller so the transaction
+    /// can still roll back. Handlers the consumer never drains run at the
+    /// <see cref="AfterCommit"/> point instead, with a logged warning (fail-open).
+    /// </summary>
+    AfterFlush = 1,
+
+    /// <summary>
+    /// Queued at raise time; drained by the framework when the <i>entry</i> factory call
+    /// completes successfully. Strictly, this means "after the entry factory method body
+    /// returns" — it is "after commit" because consumers commit inside their factory
+    /// bodies, which is the universal RemoteFactory pattern. Handlers run with no ambient
+    /// transaction; a handler exception cannot roll anything back, so the framework logs
+    /// it and continues (<see cref="OperationCanceledException"/> still propagates).
+    /// Events raised by these handlers still join the same response's relay batch.
+    /// The right phase for read-only projections.
+    /// </summary>
+    AfterCommit = 2,
+}

--- a/src/RemoteFactory/FactoryAttributes.cs
+++ b/src/RemoteFactory/FactoryAttributes.cs
@@ -113,43 +113,6 @@ public sealed class ExecuteAttribute : FactoryOperationAttribute
 	public ExecuteAttribute() : base(FactoryOperation.Execute) { }
 }
 
-/// <summary>
-/// Marks a class as a handler for factory events of type <typeparamref name="T"/>.
-/// The handler method must be <c>static</c>, return <see cref="Task"/>, and have a first
-/// non-[Service]/non-CancellationToken parameter of type <typeparamref name="T"/>.
-/// <para>
-/// Handlers are registered in <see cref="FactoryEventHandlerRegistry"/> and dispatched
-/// via <see cref="IFactoryEvents.Raise{T}"/> on the server, in the caller's DI scope,
-/// sequentially, awaited.
-/// </para>
-/// <para>
-/// Instance-method handlers are silently ignored by the generator — they were the
-/// former client-side relay pattern, now replaced by <see cref="IFactoryEventRelay"/>.
-/// Client-side event consumers implement <see cref="IFactoryEventRelay"/> to bridge
-/// relayed events to their own event aggregator.
-/// </para>
-/// <para>
-/// <b>Trimming:</b> every generated handler registration is wrapped in
-/// <c>NeatooRuntime.IsServerRuntime</c>, so on a client published with the feature switch
-/// set to <c>false</c> the handler bodies and their <c>[Service]</c> dependencies are
-/// removed from the output. This works because the generator points the assembly's
-/// <see cref="NeatooFactoryRegistrarAttribute"/> at a generated forwarding holder rather
-/// than at the handler class itself — the attribute preserves every method on whatever it
-/// names, bodies included, so naming the handler class would ship the handler bodies to the
-/// browser. Fixed in v1.7.0; before that, it did.
-/// </para>
-/// <para>
-/// One consequence for consumers: because the registrations are server-guarded, there is
-/// nothing on a trimmed client to resolve, and handler registration cannot be verified from
-/// a client-side test. Coverage for it lives in server-side/untrimmed tests.
-/// </para>
-/// </summary>
-/// <typeparam name="T">The event type (must inherit from <see cref="FactoryEventBase"/>).</typeparam>
-[System.AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
-#pragma warning disable CA1813 // Sealed generic attribute must be unsealed for generator discovery
-public sealed class FactoryEventHandlerAttribute<T> : Attribute { }
-#pragma warning restore CA1813
-
 [System.AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 public sealed class AuthorizeFactoryAttribute<T> : Attribute
 {

--- a/src/RemoteFactory/FactoryEventHandlerAttribute.cs
+++ b/src/RemoteFactory/FactoryEventHandlerAttribute.cs
@@ -1,0 +1,61 @@
+namespace Neatoo.RemoteFactory;
+
+/// <summary>
+/// Marks a class as a handler for factory events of type <typeparamref name="T"/>.
+/// The handler method must be <c>static</c>, return <see cref="Task"/>, and have a first
+/// non-[Service]/non-CancellationToken parameter of type <typeparamref name="T"/>.
+/// <para>
+/// Handlers are registered in <see cref="FactoryEventHandlerRegistry"/> and dispatched
+/// on the server in the caller's DI scope, sequentially, awaited. <see cref="Phase"/>
+/// controls <i>when</i>: the default <see cref="DispatchPhase.Immediate"/> dispatches at
+/// <see cref="IFactoryEvents.Raise{T}"/> time, mid-transaction, observing the caller's
+/// staged (unflushed) state; <see cref="DispatchPhase.AfterFlush"/> and
+/// <see cref="DispatchPhase.AfterCommit"/> queue the dispatch and drain it later.
+/// </para>
+/// <para>
+/// Instance-method handlers are silently ignored by the generator — they were the
+/// former client-side relay pattern, now replaced by <see cref="IFactoryEventRelay"/>.
+/// Client-side event consumers implement <see cref="IFactoryEventRelay"/> to bridge
+/// relayed events to their own event aggregator.
+/// </para>
+/// <para>
+/// <b>Trimming:</b> every generated handler registration is wrapped in
+/// <c>NeatooRuntime.IsServerRuntime</c>, so on a client published with the feature switch
+/// set to <c>false</c> the handler bodies and their <c>[Service]</c> dependencies are
+/// removed from the output. This works because the generator points the assembly's
+/// <see cref="NeatooFactoryRegistrarAttribute"/> at a generated forwarding holder rather
+/// than at the handler class itself — the attribute preserves every method on whatever it
+/// names, bodies included, so naming the handler class would ship the handler bodies to the
+/// browser. Fixed in v1.7.0; before that, it did.
+/// </para>
+/// <para>
+/// One consequence for consumers: because the registrations are server-guarded, there is
+/// nothing on a trimmed client to resolve, and handler registration cannot be verified from
+/// a client-side test. Coverage for it lives in server-side/untrimmed tests.
+/// </para>
+/// <para>
+/// This attribute lives outside <c>FactoryAttributes.cs</c> deliberately: that file is
+/// linked into the netstandard2.0 Generator project, and this type references
+/// <see cref="DispatchPhase"/>. Compiling the enum into the generator assembly would make
+/// it a duplicate of the runtime's own copy in every project referencing both. The
+/// generator matches this attribute by metadata-name string, so it never needs the type.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The event type (must inherit from <see cref="FactoryEventBase"/>).</typeparam>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+#pragma warning disable CA1813 // Sealed generic attribute must be unsealed for generator discovery
+public sealed class FactoryEventHandlerAttribute<T> : Attribute
+{
+	/// <summary>Registers the handler at <see cref="DispatchPhase.Immediate"/>.</summary>
+	public FactoryEventHandlerAttribute() : this(DispatchPhase.Immediate) { }
+
+	/// <summary>Registers the handler at <paramref name="phase"/>.</summary>
+	public FactoryEventHandlerAttribute(DispatchPhase phase)
+	{
+		this.Phase = phase;
+	}
+
+	/// <summary>When the handler runs relative to the factory operation that raised the event.</summary>
+	public DispatchPhase Phase { get; }
+}
+#pragma warning restore CA1813

--- a/src/RemoteFactory/FactoryEventHandlerRegistry.cs
+++ b/src/RemoteFactory/FactoryEventHandlerRegistry.cs
@@ -14,18 +14,29 @@ public static class FactoryEventHandlerRegistry
 
     private readonly struct HandlerEntry
     {
-        public HandlerEntry(Type handlerClassType, Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> invoke)
+        public HandlerEntry(Type handlerClassType, DispatchPhase phase, Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> invoke)
         {
             HandlerClassType = handlerClassType;
+            Phase = phase;
             Invoke = invoke;
         }
 
         public Type HandlerClassType { get; }
+        public DispatchPhase Phase { get; }
         public Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Invoke { get; }
     }
 
     /// <summary>
-    /// Registers a handler factory for the given event type.
+    /// Registers a handler factory for the given event type at <see cref="DispatchPhase.Immediate"/>.
+    /// </summary>
+    public static void RegisterHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEvent>(
+        Type handlerClassType,
+        Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> handlerFactory)
+        where TEvent : FactoryEventBase
+        => RegisterHandler<TEvent>(handlerClassType, DispatchPhase.Immediate, handlerFactory);
+
+    /// <summary>
+    /// Registers a handler factory for the given event type at <paramref name="phase"/>.
     /// Called by generated <c>FactoryServiceRegistrar</c> methods during DI setup.
     /// </summary>
     /// <remarks>
@@ -37,11 +48,14 @@ public static class FactoryEventHandlerRegistry
     /// </para>
     /// <para>
     /// Registrations are deduplicated by the <c>(event type, handler class type)</c> pair
-    /// so multiple DI container builds in a test run do not multiply registrations.
+    /// so multiple DI container builds in a test run do not multiply registrations. One
+    /// consequence: a handler class declaring the same event type twice at different
+    /// phases keeps the phase registered first, for the life of the process.
     /// </para>
     /// </remarks>
     public static void RegisterHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEvent>(
         Type handlerClassType,
+        DispatchPhase phase,
         Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> handlerFactory)
         where TEvent : FactoryEventBase
     {
@@ -51,21 +65,22 @@ public static class FactoryEventHandlerRegistry
             // Avoid duplicate registration from multiple DI container setups in tests.
             if (!list.Any(e => e.HandlerClassType == handlerClassType))
             {
-                list.Add(new HandlerEntry(handlerClassType, handlerFactory));
+                list.Add(new HandlerEntry(handlerClassType, phase, handlerFactory));
             }
         }
     }
 
     /// <summary>
-    /// Gets all registered handler factories for the given event type.
+    /// Gets all registered handler factories for the given event type, paired with the
+    /// phase each was registered at.
     /// </summary>
-    internal static IReadOnlyList<Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task>>? GetHandlers(Type eventType)
+    internal static IReadOnlyList<(DispatchPhase Phase, Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Invoke)>? GetHandlers(Type eventType)
     {
         if (!_handlers.TryGetValue(eventType, out var handlers))
             return null;
         lock (handlers)
         {
-            return handlers.Select(h => h.Invoke).ToArray();
+            return handlers.Select(h => (h.Phase, h.Invoke)).ToArray();
         }
     }
 

--- a/src/RemoteFactory/FactoryEventsDispatcher.cs
+++ b/src/RemoteFactory/FactoryEventsDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Neatoo.RemoteFactory.Internal;
 
 namespace Neatoo.RemoteFactory;
@@ -10,20 +11,29 @@ namespace Neatoo.RemoteFactory;
 /// Each handler was registered by a generated <c>FactoryServiceRegistrar</c> during DI setup.
 /// </summary>
 /// <remarks>
-/// Handlers run <b>sequentially</b> in the caller's <see cref="IServiceProvider"/> so that
-/// a <c>DbContext</c> (or any other scoped service) is shared between the factory method
-/// and its handlers. A handler exception aborts the remaining handlers and propagates to
-/// the caller, so the caller can let the transaction roll back.
+/// <para>
+/// <see cref="DispatchPhase.Immediate"/> handlers — the default — run <b>sequentially</b>
+/// in the caller's <see cref="IServiceProvider"/> so that a <c>DbContext</c> (or any other
+/// scoped service) is shared between the factory method and its handlers. A handler
+/// exception aborts the remaining handlers and propagates to the caller, so the caller can
+/// let the transaction roll back.
+/// </para>
+/// <para>
+/// Handlers registered at another phase are queued in the scope's
+/// <see cref="IFactoryEventPhaseScheduler"/> instead, and run when that phase drains.
+/// </para>
 /// </remarks>
 internal sealed class FactoryEventsDispatcher : IFactoryEvents
 {
     private readonly IServiceProvider _sp;
     private readonly IFactoryEventCollector? _collector;
+    private readonly IFactoryEventPhaseScheduler? _phaseQueue;
 
     public FactoryEventsDispatcher(IServiceProvider sp)
     {
         _sp = sp;
         _collector = sp.GetService<IFactoryEventCollector>();
+        _phaseQueue = sp.GetService<IFactoryEventPhaseScheduler>();
     }
 
     public Task Raise<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T factoryEvent, RaiseOptions options = RaiseOptions.None, CancellationToken cancellationToken = default) where T : FactoryEventBase
@@ -51,8 +61,24 @@ internal sealed class FactoryEventsDispatcher : IFactoryEvents
         // Sequential dispatch in the caller's scope. Handler order is unspecified —
         // callers must not depend on it. Exceptions propagate immediately and abort
         // the remaining handlers so the caller's transaction can roll back.
-        foreach (var handler in handlers)
+        //
+        // Phased handlers are queued instead, and run when their phase drains. Without a
+        // queue in the scope they fall back to immediate dispatch rather than vanishing.
+        foreach (var (phase, handler) in handlers)
         {
+            if (phase != DispatchPhase.Immediate)
+            {
+                if (_phaseQueue != null)
+                {
+                    _phaseQueue.Enqueue(phase, (FactoryEventBase)factoryEvent, options, handler);
+                    continue;
+                }
+
+                _sp.GetService<ILoggerFactory>()?
+                    .CreateLogger(NeatooLoggerCategories.Server)
+                    .FactoryEventPhaseNoQueueInScope(eventType.Name, phase);
+            }
+
             await handler(_sp, factoryEvent, options, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/RemoteFactory/IFactoryEvents.cs
+++ b/src/RemoteFactory/IFactoryEvents.cs
@@ -8,16 +8,25 @@ namespace Neatoo.RemoteFactory;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Execution model.</b> <c>Raise</c> is always shared-scope, sequential, and awaited:
-/// handlers share the caller's DI scope (so a <c>DbContext</c> injected into the factory
-/// method and a <c>DbContext</c> injected into a handler are the same instance), run one
-/// after another in unspecified order, and any handler exception aborts the remaining
-/// handlers and propagates to the caller. Across the client/server boundary the HTTP call
-/// stays open until every server-side handler has completed.
+/// <b>Execution model.</b> <c>Raise</c> is shared-scope, sequential, and awaited: handlers
+/// share the caller's DI scope (so a <c>DbContext</c> injected into the factory method and
+/// a <c>DbContext</c> injected into a handler are the same instance), run one after another
+/// in unspecified order, and any handler exception aborts the remaining handlers and
+/// propagates to the caller. Across the client/server boundary the HTTP call stays open
+/// until every server-side handler has completed.
 /// </para>
 /// <para>
 /// This makes <c>FactoryEvent</c> the right tool for domain events that must participate
 /// in the caller's transaction.
+/// </para>
+/// <para>
+/// <b>Phases.</b> The above is the <see cref="DispatchPhase.Immediate"/> contract — the
+/// default, and the only behavior before phases existed. A handler registered at another
+/// <see cref="DispatchPhase"/> is queued when the event is raised and dispatched when that
+/// phase drains, so <c>Raise</c> returning no longer means every handler has run. Handlers
+/// that must be atomic with the caller's transaction stay <see cref="DispatchPhase.Immediate"/>;
+/// read-only projections that need to see the completed operation use
+/// <see cref="DispatchPhase.AfterCommit"/>.
 /// </para>
 /// </remarks>
 public interface IFactoryEvents

--- a/src/RemoteFactory/Internal/FactoryEventPhaseScheduler.cs
+++ b/src/RemoteFactory/Internal/FactoryEventPhaseScheduler.cs
@@ -1,0 +1,156 @@
+using Microsoft.Extensions.Logging;
+
+namespace Neatoo.RemoteFactory.Internal;
+
+/// <summary>
+/// Scope-scoped store of factory-event dispatches deferred by their
+/// <see cref="DispatchPhase"/>, plus the drain primitive that runs them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Public because generated factory code calls <see cref="DrainAsync"/> at the entry-call
+/// boundary; it lives in the <c>Internal</c> namespace alongside
+/// <see cref="IMakeRemoteDelegateRequest"/> and <see cref="ICorrelationContext"/>, which
+/// are public for the same reason.
+/// </para>
+/// <para>
+/// State is per DI scope and holds no persistence concepts. A scope whose factory
+/// operation fails is simply never drained — that is what makes rollback-discard
+/// structural rather than a rule anyone has to remember.
+/// </para>
+/// </remarks>
+public interface IFactoryEventPhaseScheduler
+{
+    /// <summary>True when any phase has deferred dispatches waiting.</summary>
+    bool HasPending { get; }
+
+    /// <summary>Defers a handler dispatch until <paramref name="phase"/> drains.</summary>
+    void Enqueue(DispatchPhase phase, FactoryEventBase factoryEvent, RaiseOptions options, Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> handler);
+
+    /// <summary>
+    /// Runs the deferred dispatches for <paramref name="phase"/> <b>and every earlier
+    /// phase</b>, earliest first, until none are left.
+    /// </summary>
+    /// <remarks>
+    /// Draining earlier phases too is what makes the drain total: a handler running here
+    /// can raise an event whose handlers sit in this phase or in one whose drain point has
+    /// already passed, and a consumer may never drain <see cref="DispatchPhase.AfterFlush"/>
+    /// at all. Either way the work joins this drain rather than being silently dropped.
+    /// Later phases than <paramref name="phase"/> are left alone.
+    /// </remarks>
+    /// <param name="phase">The latest phase to drain; earlier phases drain first.</param>
+    /// <param name="inTransaction">
+    /// Declares the <i>drain point</i>, which is what failure semantics key off — not the
+    /// phase. <see langword="true"/> when the caller still has a transaction open, so a
+    /// handler exception propagates and the caller can roll back. <see langword="false"/>
+    /// for a post-completion drain, where a throw can no longer roll anything back and is
+    /// therefore logged and swallowed per handler;
+    /// <see cref="OperationCanceledException"/> still propagates.
+    /// </param>
+    /// <param name="cancellationToken">Token passed to the drained handlers.</param>
+    Task DrainAsync(DispatchPhase phase, bool inTransaction, CancellationToken cancellationToken = default);
+}
+
+internal sealed class FactoryEventPhaseScheduler : IFactoryEventPhaseScheduler
+{
+    private readonly IServiceProvider _sp;
+    private readonly ILogger? _logger;
+    private readonly Dictionary<DispatchPhase, Queue<QueuedDispatch>> _deferred = new();
+
+    public FactoryEventPhaseScheduler(IServiceProvider sp, ILoggerFactory? loggerFactory = null)
+    {
+        _sp = sp;
+        _logger = loggerFactory?.CreateLogger(NeatooLoggerCategories.Server);
+    }
+
+    private readonly record struct QueuedDispatch(
+        FactoryEventBase Event,
+        RaiseOptions Options,
+        Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Handler);
+
+    public bool HasPending => _deferred.Any(q => q.Value.Count > 0);
+
+    public void Enqueue(DispatchPhase phase, FactoryEventBase factoryEvent, RaiseOptions options, Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> handler)
+    {
+        ArgumentNullException.ThrowIfNull(factoryEvent);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!_deferred.TryGetValue(phase, out var queue))
+        {
+            queue = new Queue<QueuedDispatch>();
+            _deferred[phase] = queue;
+        }
+
+        queue.Enqueue(new QueuedDispatch(factoryEvent, options, handler));
+
+        if (_logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            _logger.FactoryEventPhaseQueued(factoryEvent.GetType().Name, phase);
+        }
+    }
+
+    public async Task DrainAsync(DispatchPhase phase, bool inTransaction, CancellationToken cancellationToken = default)
+    {
+        var drained = 0;
+
+        // Dequeue one at a time rather than snapshotting: a handler running here may raise
+        // an event whose handlers are deferred, and those dispatches belong to this drain.
+        // TryDequeueThrough also picks up earlier phases, which a handler can still enqueue
+        // into after that phase's own drain point has passed — without this they would sit
+        // in a scope nobody drains again. An unterminated raise loop is the consumer's bug,
+        // exactly as it is for today's synchronous chained raises.
+        while (TryDequeueThrough(phase, out var dispatch, out var dispatchPhase))
+        {
+            drained++;
+
+            if (inTransaction)
+            {
+                await dispatch.Handler(_sp, dispatch.Event, dispatch.Options, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+#pragma warning disable CA1031 // Post-completion handler exceptions cannot roll anything back; swallowing is the contract.
+            try
+            {
+                await dispatch.Handler(_sp, dispatch.Event, dispatch.Options, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.FactoryEventPhaseHandlerFailed(dispatchPhase, dispatch.Event.GetType().Name, ex);
+            }
+#pragma warning restore CA1031
+        }
+
+        if (drained > 0 && _logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            _logger.FactoryEventPhaseDrained(drained, phase);
+        }
+    }
+
+    /// <summary>
+    /// Takes the next dispatch from the earliest non-empty phase at or before
+    /// <paramref name="through"/>, so cross-phase ordering holds even for work a handler
+    /// enqueues mid-drain.
+    /// </summary>
+    private bool TryDequeueThrough(DispatchPhase through, out QueuedDispatch dispatch, out DispatchPhase phase)
+    {
+        foreach (var candidate in _deferred.Keys.Where(p => p <= through).OrderBy(p => p))
+        {
+            var queue = _deferred[candidate];
+            if (queue.Count > 0)
+            {
+                dispatch = queue.Dequeue();
+                phase = candidate;
+                return true;
+            }
+        }
+
+        dispatch = default;
+        phase = through;
+        return false;
+    }
+}

--- a/src/RemoteFactory/Internal/Log.cs
+++ b/src/RemoteFactory/Internal/Log.cs
@@ -470,4 +470,43 @@ internal static partial class Log
         string typeName,
         long elapsedMs,
         int jsonLength);
+
+    // ===== Phased Event Dispatch (9xxx) =====
+
+    [LoggerMessage(
+        EventId = 9001,
+        Level = LogLevel.Debug,
+        Message = "Factory event {EventType} queued for {Phase} dispatch")]
+    public static partial void FactoryEventPhaseQueued(
+        this ILogger logger,
+        string eventType,
+        DispatchPhase phase);
+
+    [LoggerMessage(
+        EventId = 9002,
+        Level = LogLevel.Debug,
+        Message = "Drained {HandlerCount} queued handler dispatch(es) through phase {Phase}")]
+    public static partial void FactoryEventPhaseDrained(
+        this ILogger logger,
+        int handlerCount,
+        DispatchPhase phase);
+
+    [LoggerMessage(
+        EventId = 9003,
+        Level = LogLevel.Error,
+        Message = "A {Phase} handler for factory event {EventType} threw after the factory operation completed; the exception was logged and swallowed because it can no longer roll anything back. Remaining queued handlers still run.")]
+    public static partial void FactoryEventPhaseHandlerFailed(
+        this ILogger logger,
+        DispatchPhase phase,
+        string eventType,
+        Exception? exception);
+
+    [LoggerMessage(
+        EventId = 9004,
+        Level = LogLevel.Debug,
+        Message = "Factory event {EventType} has a {Phase} handler but no phase queue exists in this scope; dispatching it immediately instead.")]
+    public static partial void FactoryEventPhaseNoQueueInScope(
+        this ILogger logger,
+        string eventType,
+        DispatchPhase phase);
 }

--- a/src/RemoteFactory/RaiseOptions.cs
+++ b/src/RemoteFactory/RaiseOptions.cs
@@ -5,11 +5,17 @@ namespace Neatoo.RemoteFactory;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>FactoryEvent</c> raises are always <b>shared-scope, sequential, and awaited</b>:
-/// handlers share the caller's DI scope (and therefore the caller's <c>DbContext</c> and
+/// <c>FactoryEvent</c> raises are <b>shared-scope, sequential, and awaited</b>: handlers
+/// share the caller's DI scope (and therefore the caller's <c>DbContext</c> and
 /// transaction), run one after another in unspecified order, and any handler exception
 /// aborts the remaining handlers and propagates to the caller. Across the client/server
 /// boundary the HTTP call stays open until every server-side handler completes.
+/// </para>
+/// <para>
+/// That describes <see cref="DispatchPhase.Immediate"/> handlers, which is the default and
+/// was the only behavior before phases existed. Handlers registered at another
+/// <see cref="DispatchPhase"/> are queued at raise time and run when their phase drains —
+/// still in the same scope, but no longer before <c>Raise</c> returns.
 /// </para>
 /// </remarks>
 [Flags]

--- a/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseRegistrationTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseRegistrationTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.DependencyInjection;
+using Neatoo.RemoteFactory;
+using Neatoo.RemoteFactory.Internal;
+
+namespace RemoteFactory.UnitTests.Internal;
+
+/// <summary>
+/// Covers phase-aware handler registration and the DI registration of the phase queue
+/// across NeatooFactory modes.
+/// </summary>
+public class FactoryEventPhaseRegistrationTests
+{
+    private sealed record RegistrationEventA(string Value) : FactoryEventBase;
+    private sealed record RegistrationEventB(string Value) : FactoryEventBase;
+    private sealed record RegistrationEventC(string Value) : FactoryEventBase;
+    private sealed record RegistrationEventD(string Value) : FactoryEventBase;
+
+    private sealed class HandlerOne { }
+    private sealed class HandlerTwo { }
+
+    private static Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> NoOp
+        => (_, _, _, _) => Task.CompletedTask;
+
+    [Fact]
+    public void RegisterHandler_WithoutPhase_DefaultsToImmediate()
+    {
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventA>(typeof(HandlerOne), NoOp);
+
+        var handlers = FactoryEventHandlerRegistry.GetHandlers(typeof(RegistrationEventA));
+
+        Assert.NotNull(handlers);
+        var entry = Assert.Single(handlers);
+        Assert.Equal(DispatchPhase.Immediate, entry.Phase);
+    }
+
+    [Fact]
+    public void RegisterHandler_WithPhase_RoundTripsThePhase()
+    {
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventB>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventB>(typeof(HandlerTwo), DispatchPhase.AfterFlush, NoOp);
+
+        var handlers = FactoryEventHandlerRegistry.GetHandlers(typeof(RegistrationEventB));
+
+        Assert.NotNull(handlers);
+        Assert.Equal(2, handlers.Count);
+        Assert.Contains(handlers, h => h.Phase == DispatchPhase.AfterCommit);
+        Assert.Contains(handlers, h => h.Phase == DispatchPhase.AfterFlush);
+    }
+
+    [Fact]
+    public void RegisterHandler_RepeatedContainerBuilds_DedupesByEventAndHandlerClass()
+    {
+        // Simulates multiple DI container builds in one test run.
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventC>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventC>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventC>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
+
+        var handlers = FactoryEventHandlerRegistry.GetHandlers(typeof(RegistrationEventC));
+
+        Assert.NotNull(handlers);
+        Assert.Single(handlers);
+    }
+
+    [Fact]
+    public void RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration()
+    {
+        // Documents the interim semantics of the (eventType, handlerClassType) dedupe key:
+        // a handler class declaring one event at two phases keeps the phase registered
+        // first, for the life of the process. PHASE-002 decides whether the generator
+        // should diagnose this instead.
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventD>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
+        FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventD>(typeof(HandlerOne), DispatchPhase.Immediate, NoOp);
+
+        var handlers = FactoryEventHandlerRegistry.GetHandlers(typeof(RegistrationEventD));
+
+        Assert.NotNull(handlers);
+        var entry = Assert.Single(handlers);
+        Assert.Equal(DispatchPhase.AfterCommit, entry.Phase);
+    }
+
+    [Fact]
+    public void Attribute_NoArgument_DefaultsToImmediate()
+    {
+        var attribute = new FactoryEventHandlerAttribute<RegistrationEventA>();
+
+        Assert.Equal(DispatchPhase.Immediate, attribute.Phase);
+    }
+
+    [Theory]
+    [InlineData(DispatchPhase.Immediate)]
+    [InlineData(DispatchPhase.AfterFlush)]
+    [InlineData(DispatchPhase.AfterCommit)]
+    public void Attribute_ExplicitPhase_RoundTrips(DispatchPhase phase)
+    {
+        var attribute = new FactoryEventHandlerAttribute<RegistrationEventA>(phase);
+
+        Assert.Equal(phase, attribute.Phase);
+    }
+
+    [Theory]
+    [InlineData(NeatooFactory.Server)]
+    [InlineData(NeatooFactory.Logical)]
+    public void PhaseDispatcher_RegisteredInModesThatDispatchHandlers(NeatooFactory mode)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeatooRemoteFactory(mode, typeof(FactoryEventPhaseRegistrationTests).Assembly);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetService<IFactoryEventPhaseScheduler>());
+    }
+
+    [Fact]
+    public void PhaseDispatcher_NotRegisteredInRemoteMode()
+    {
+        // Remote mode sends raises to the server; no handlers dispatch client-side, so
+        // there is nothing to defer.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeatooRemoteFactory(NeatooFactory.Remote, typeof(FactoryEventPhaseRegistrationTests).Assembly);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.Null(scope.ServiceProvider.GetService<IFactoryEventPhaseScheduler>());
+    }
+
+    [Fact]
+    public void PhaseDispatcher_IsScoped_NotSharedAcrossScopes()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeatooRemoteFactory(NeatooFactory.Server, typeof(FactoryEventPhaseRegistrationTests).Assembly);
+
+        using var provider = services.BuildServiceProvider();
+        using var scopeA = provider.CreateScope();
+        using var scopeB = provider.CreateScope();
+
+        var a = scopeA.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+        var b = scopeB.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+
+        Assert.NotSame(a, b);
+
+        a.Enqueue(DispatchPhase.AfterCommit, new RegistrationEventA("x"), RaiseOptions.None, NoOp);
+
+        Assert.True(a.HasPending);
+        Assert.False(b.HasPending);
+    }
+}

--- a/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseSchedulerTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseSchedulerTests.cs
@@ -1,0 +1,409 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Neatoo.RemoteFactory;
+using Neatoo.RemoteFactory.Internal;
+
+namespace RemoteFactory.UnitTests.Internal;
+
+/// <summary>
+/// Covers the phase queue and its drain primitive: what gets deferred, what order it
+/// drains in, and which drain points propagate handler exceptions versus swallow them.
+/// </summary>
+public class FactoryEventPhaseSchedulerTests
+{
+    private sealed record PhaseTestEvent(string Value) : FactoryEventBase;
+
+    private static IFactoryEventPhaseScheduler NewDispatcher()
+        => NewDispatcher(out _);
+
+    private static IFactoryEventPhaseScheduler NewDispatcher(out CapturingLoggerProvider logs)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var captured = new CapturingLoggerProvider();
+        // Not disposed: the dispatcher holds a logger created from this factory for the
+        // lifetime of the test.
+        var loggerFactory = LoggerFactory.Create(b =>
+        {
+            b.SetMinimumLevel(LogLevel.Debug);
+            b.AddProvider(captured);
+        });
+        logs = captured;
+        return new FactoryEventPhaseScheduler(services.BuildServiceProvider(), loggerFactory);
+    }
+
+    private sealed record LogEntry(int EventId, LogLevel Level, Exception? Exception, DispatchPhase? Phase);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(CapturingLoggerProvider owner) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                DispatchPhase? phase = null;
+                if (state is IReadOnlyList<KeyValuePair<string, object?>> values)
+                {
+                    foreach (var pair in values)
+                    {
+                        if (pair.Key == "Phase" && pair.Value is DispatchPhase p)
+                        {
+                            phase = p;
+                        }
+                    }
+                }
+
+                lock (owner.Entries)
+                {
+                    owner.Entries.Add(new LogEntry(eventId.Id, logLevel, exception, phase));
+                }
+            }
+        }
+    }
+
+    private static Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Recording(List<string> log, string name)
+        => (_, _, _, _) =>
+        {
+            log.Add(name);
+            return Task.CompletedTask;
+        };
+
+    private static Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Throwing(Exception ex)
+        => (_, _, _, _) => throw ex;
+
+    [Fact]
+    public void Enqueue_DoesNotInvokeHandler()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "handler"));
+
+        Assert.Empty(log);
+        Assert.True(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_RunsDeferredDispatchesInFifoOrder()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "first"));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "second"));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("c"), RaiseOptions.None, Recording(log, "third"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["first", "second", "third"], log);
+        Assert.False(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_OnlyDrainsTheRequestedPhase()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "flush"));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "commit"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterFlush, inTransaction: true);
+
+        Assert.Equal(["flush"], log);
+        Assert.True(dispatcher.HasPending);
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["flush", "commit"], log);
+        Assert.False(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_PostCompletion_SwallowsHandlerExceptionAndRunsTheRest()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "before"));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("b"), RaiseOptions.None, Throwing(new InvalidOperationException("read-side blew up")));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("c"), RaiseOptions.None, Recording(log, "after"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["before", "after"], log);
+    }
+
+    [Fact]
+    public async Task DrainAsync_PostCompletion_StillPropagatesCancellation()
+    {
+        var dispatcher = NewDispatcher();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Throwing(new OperationCanceledException()));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false));
+    }
+
+    [Fact]
+    public async Task DrainAsync_InTransaction_PropagatesHandlerExceptionAndAbortsRemaining()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("a"), RaiseOptions.None, Throwing(new InvalidOperationException("write-side blew up")));
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "never runs"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DrainAsync(DispatchPhase.AfterFlush, inTransaction: true));
+
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public async Task DrainAsync_SamePhaseHandlersDrainPoint_KeysSemanticsNotThePhase()
+    {
+        // The same AfterFlush handlers get swallow semantics when drained at a
+        // post-completion point (the fail-open path a consumer who never drains hits).
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("a"), RaiseOptions.None, Throwing(new InvalidOperationException("boom")));
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "still runs"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterFlush, inTransaction: false);
+
+        Assert.Equal(["still runs"], log);
+    }
+
+    [Fact]
+    public async Task DrainAsync_ReentrantEnqueueDuringDrain_RunsInTheSameDrain()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, (_, _, _, _) =>
+        {
+            log.Add("outer");
+            // A handler raising an event whose handlers land in the phase being drained.
+            dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("nested"), RaiseOptions.None, Recording(log, "nested"));
+            return Task.CompletedTask;
+        });
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["outer", "nested"], log);
+        Assert.False(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_NothingDeferred_IsANoOp()
+    {
+        var dispatcher = NewDispatcher();
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.False(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_DeferredDispatchesRunOnce_NotOnASecondDrain()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "handler"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["handler"], log);
+    }
+
+    [Fact]
+    public async Task DrainAsync_ReentrantEnqueueIntoAnAlreadyPassedPhase_StillRunsInThisDrain()
+    {
+        // The AfterCommit drain is the last one a scope gets. A handler running there that
+        // raises an event with an AfterFlush handler would otherwise leave that dispatch in
+        // a scope nobody drains again.
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, (_, _, _, _) =>
+        {
+            log.Add("commit");
+            dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("late"), RaiseOptions.None, Recording(log, "late-flush"));
+            return Task.CompletedTask;
+        });
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["commit", "late-flush"], log);
+        Assert.False(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_SweepsAnEarlierPhaseTheConsumerNeverDrained()
+    {
+        // Fail-open: a consumer who never calls the AfterFlush drain point must not lose
+        // those handlers. The AfterCommit drain sweeps them up, earliest phase first, and
+        // they take the post-completion drain point's swallow semantics.
+        var dispatcher = NewDispatcher(out var logs);
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("a"), RaiseOptions.None, Throwing(new InvalidOperationException("flush-side blew up")));
+        dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "flush"));
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("c"), RaiseOptions.None, Recording(log, "commit"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["flush", "commit"], log);
+        Assert.False(dispatcher.HasPending);
+
+        // The failure is attributed to the phase the dispatch was queued at, not the phase
+        // that was requested.
+        var failure = Assert.Single(logs.Entries, e => e.EventId == 9003);
+        Assert.Equal(DispatchPhase.AfterFlush, failure.Phase);
+    }
+
+    [Fact]
+    public async Task DrainAsync_MidDrainEarlierPhaseWork_PreemptsRemainingLaterPhaseWork()
+    {
+        // Pins the ordering choice rather than leaving it accidental: earlier-phase work
+        // created mid-drain runs before later-phase dispatches that were already queued.
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, (_, _, _, _) =>
+        {
+            log.Add("commit1");
+            dispatcher.Enqueue(DispatchPhase.AfterFlush, new PhaseTestEvent("late"), RaiseOptions.None, Recording(log, "late-flush"));
+            return Task.CompletedTask;
+        });
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("b"), RaiseOptions.None, Recording(log, "commit2"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal(["commit1", "late-flush", "commit2"], log);
+    }
+
+    [Fact]
+    public async Task DrainAsync_DoesNotRunLaterPhasesThanRequested()
+    {
+        var dispatcher = NewDispatcher();
+        var log = new List<string>();
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "commit"));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterFlush, inTransaction: true);
+
+        Assert.Empty(log);
+        Assert.True(dispatcher.HasPending);
+    }
+
+    [Fact]
+    public async Task DrainAsync_PostCompletionSwallow_LogsTheDedicatedEventIdWithTheException()
+    {
+        var dispatcher = NewDispatcher(out var logs);
+        var boom = new InvalidOperationException("read-side blew up");
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Throwing(boom));
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        var failure = Assert.Single(logs.Entries, e => e.EventId == 9003);
+        Assert.Equal(LogLevel.Error, failure.Level);
+        Assert.Same(boom, failure.Exception);
+    }
+
+    [Fact]
+    public async Task DrainAsync_HandlerReceivesTheEventAndOptionsItWasQueuedWith()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var scopeProvider = services.BuildServiceProvider();
+        var dispatcher = new FactoryEventPhaseScheduler(scopeProvider);
+
+        var seen = new List<(string Value, RaiseOptions Options)>();
+        var providers = new List<IServiceProvider>();
+
+        Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> capture =
+            (sp, evt, options, _) =>
+            {
+                seen.Add((((PhaseTestEvent)evt).Value, options));
+                providers.Add(sp);
+                return Task.CompletedTask;
+            };
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("first"), RaiseOptions.None, capture);
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("second"), RaiseOptions.ServerOnly, capture);
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+        Assert.Equal([("first", RaiseOptions.None), ("second", RaiseOptions.ServerOnly)], seen);
+        // Handlers resolve their [Service] dependencies from the originating scope.
+        Assert.All(providers, sp => Assert.Same(scopeProvider, sp));
+        Assert.Equal(2, providers.Count);
+    }
+
+    [Fact]
+    public async Task DrainAsync_HandlerReceivesTheDrainTimeCancellationToken()
+    {
+        // The token is supplied at drain time, not captured at raise time. PHASE-003 owns
+        // the policy question of which token a post-completion drain should pass; this
+        // pins the plumbing it will reason from.
+        var dispatcher = NewDispatcher();
+        using var drainCts = new CancellationTokenSource();
+        CancellationToken received = default;
+
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, (_, _, _, ct) =>
+        {
+            received = ct;
+            return Task.CompletedTask;
+        });
+
+        await dispatcher.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false, drainCts.Token);
+
+        Assert.Equal(drainCts.Token, received);
+    }
+
+    [Fact]
+    public void Enqueue_NullEvent_Throws()
+    {
+        var dispatcher = NewDispatcher();
+
+        Assert.Throws<ArgumentNullException>(
+            () => dispatcher.Enqueue(DispatchPhase.AfterCommit, null!, RaiseOptions.None, (_, _, _, _) => Task.CompletedTask));
+    }
+
+    [Fact]
+    public void ScopeDisposedWithoutDraining_RunsNothing()
+    {
+        // Rollback-discard: a scope whose factory operation failed is never drained. The
+        // dispatcher must not run deferred work on the way out.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeatooRemoteFactory(NeatooFactory.Server, typeof(FactoryEventPhaseSchedulerTests).Assembly);
+
+        using var provider = services.BuildServiceProvider();
+        var log = new List<string>();
+
+        var scope = provider.CreateScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+        dispatcher.Enqueue(DispatchPhase.AfterCommit, new PhaseTestEvent("a"), RaiseOptions.None, Recording(log, "handler"));
+        Assert.True(dispatcher.HasPending);
+
+        scope.Dispose();
+
+        Assert.Empty(log);
+    }
+}

--- a/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventsDispatcherPhaseTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventsDispatcherPhaseTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.DependencyInjection;
+using Neatoo.RemoteFactory;
+using Neatoo.RemoteFactory.Internal;
+
+namespace RemoteFactory.UnitTests.Internal;
+
+/// <summary>
+/// Covers what <see cref="IFactoryEvents.Raise{T}"/> does with phase-registered handlers:
+/// Immediate dispatches as it always has, other phases defer to the scope's queue.
+/// </summary>
+public class FactoryEventsDispatcherPhaseTests
+{
+    private sealed record ImmediateOnlyEvent(string Value) : FactoryEventBase;
+    private sealed record DeferredOnlyEvent(string Value) : FactoryEventBase;
+    private sealed record MixedPhaseEvent(string Value) : FactoryEventBase;
+    private sealed record RelayCollectionEvent(string Value) : FactoryEventBase;
+    private sealed record UntypedRaiseEvent(string Value) : FactoryEventBase;
+    private sealed record ChainedSourceEvent(string Value) : FactoryEventBase;
+    private sealed record ChainedFollowUpEvent(string Value) : FactoryEventBase;
+    private sealed record NoQueueEvent(string Value) : FactoryEventBase;
+
+    private sealed class ImmediateHandler { }
+    private sealed class DeferredHandler { }
+
+    private static readonly List<string> Dispatched = [];
+
+    private static Func<IServiceProvider, object, RaiseOptions, CancellationToken, Task> Recording(string name)
+        => (_, _, _, _) =>
+        {
+            lock (Dispatched)
+            {
+                Dispatched.Add(name);
+            }
+            return Task.CompletedTask;
+        };
+
+    private static (ServiceProvider Provider, IServiceScope Scope) ServerScope()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeatooRemoteFactory(NeatooFactory.Server, typeof(FactoryEventsDispatcherPhaseTests).Assembly);
+        var provider = services.BuildServiceProvider();
+        return (provider, provider.CreateScope());
+    }
+
+    [Fact]
+    public async Task Raise_ImmediateHandler_DispatchesAtRaiseTime()
+    {
+        lock (Dispatched) { Dispatched.Clear(); }
+        FactoryEventHandlerRegistry.RegisterHandler<ImmediateOnlyEvent>(typeof(ImmediateHandler), DispatchPhase.Immediate, Recording("immediate"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+
+            await events.Raise(new ImmediateOnlyEvent("x"));
+
+            lock (Dispatched)
+            {
+                Assert.Equal(["immediate"], Dispatched);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Raise_DeferredHandler_DoesNotDispatchAtRaiseTime()
+    {
+        lock (Dispatched) { Dispatched.Clear(); }
+        FactoryEventHandlerRegistry.RegisterHandler<DeferredOnlyEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var queue = scope.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+
+            await events.Raise(new DeferredOnlyEvent("x"));
+
+            lock (Dispatched)
+            {
+                Assert.Empty(Dispatched);
+            }
+            Assert.True(queue.HasPending);
+
+            await queue.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+            lock (Dispatched)
+            {
+                Assert.Equal(["deferred"], Dispatched);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Raise_MixedPhases_ImmediateRunsAndDeferredWaits()
+    {
+        lock (Dispatched) { Dispatched.Clear(); }
+        FactoryEventHandlerRegistry.RegisterHandler<MixedPhaseEvent>(typeof(ImmediateHandler), DispatchPhase.Immediate, Recording("immediate"));
+        FactoryEventHandlerRegistry.RegisterHandler<MixedPhaseEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var queue = scope.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+
+            await events.Raise(new MixedPhaseEvent("x"));
+
+            lock (Dispatched)
+            {
+                Assert.Equal(["immediate"], Dispatched);
+            }
+
+            await queue.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+            // Cross-phase ordering: the Immediate handler completed before the deferred one ran.
+            lock (Dispatched)
+            {
+                Assert.Equal(["immediate", "deferred"], Dispatched);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RaiseUntyped_DeferredHandler_DefersJustLikeRaise()
+    {
+        // RaiseUntyped is the path client-raised events take server-side, so it is the
+        // entry point for the most interesting phase case.
+        lock (Dispatched) { Dispatched.Clear(); }
+        FactoryEventHandlerRegistry.RegisterHandler<UntypedRaiseEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var queue = scope.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+
+            await events.RaiseUntyped(new UntypedRaiseEvent("x"));
+
+            lock (Dispatched)
+            {
+                Assert.Empty(Dispatched);
+            }
+            Assert.True(queue.HasPending);
+
+            await queue.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+            lock (Dispatched)
+            {
+                Assert.Equal(["deferred"], Dispatched);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DrainedHandlerRaisingAnEvent_GoesThroughTheRealRaisePath()
+    {
+        // Re-entrancy as production hits it: handler -> IFactoryEvents.Raise -> registry
+        // lookup -> defer, rather than calling Enqueue directly.
+        lock (Dispatched) { Dispatched.Clear(); }
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var queue = scope.ServiceProvider.GetRequiredService<IFactoryEventPhaseScheduler>();
+
+            FactoryEventHandlerRegistry.RegisterHandler<ChainedFollowUpEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("follow-up"));
+            FactoryEventHandlerRegistry.RegisterHandler<ChainedSourceEvent>(typeof(ImmediateHandler), DispatchPhase.AfterCommit, async (sp, _, _, ct) =>
+            {
+                lock (Dispatched)
+                {
+                    Dispatched.Add("source");
+                }
+                await sp.GetRequiredService<IFactoryEvents>().Raise(new ChainedFollowUpEvent("chained"), RaiseOptions.None, ct);
+            });
+
+            await events.Raise(new ChainedSourceEvent("x"));
+            await queue.DrainAsync(DispatchPhase.AfterCommit, inTransaction: false);
+
+            lock (Dispatched)
+            {
+                Assert.Equal(["source", "follow-up"], Dispatched);
+            }
+            Assert.False(queue.HasPending);
+        }
+    }
+
+    [Fact]
+    public async Task Raise_PhasedHandlerWithNoQueueInScope_DispatchesImmediatelyRatherThanVanishing()
+    {
+        lock (Dispatched) { Dispatched.Clear(); }
+        FactoryEventHandlerRegistry.RegisterHandler<NoQueueEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        // A container without the phase queue registered — the fallback path in
+        // FactoryEventsDispatcher.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        using var provider = services.BuildServiceProvider();
+        var dispatcher = new FactoryEventsDispatcher(provider);
+
+        await dispatcher.Raise(new NoQueueEvent("x"));
+
+        lock (Dispatched)
+        {
+            Assert.Equal(["deferred"], Dispatched);
+        }
+    }
+
+    [Fact]
+    public async Task Raise_DeferredHandler_StillCollectsForRelayAtRaiseTime()
+    {
+        FactoryEventHandlerRegistry.RegisterHandler<RelayCollectionEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var collector = scope.ServiceProvider.GetRequiredService<IFactoryEventCollector>();
+
+            await events.Raise(new RelayCollectionEvent("x"));
+
+            var collected = Assert.Single(collector.GetCollectedEvents());
+            Assert.IsType<RelayCollectionEvent>(collected);
+        }
+    }
+
+    [Fact]
+    public async Task Raise_DeferredHandlerWithServerOnly_IsNotCollectedForRelay()
+    {
+        FactoryEventHandlerRegistry.RegisterHandler<RelayCollectionEvent>(typeof(DeferredHandler), DispatchPhase.AfterCommit, Recording("deferred"));
+
+        var (provider, scope) = ServerScope();
+        using (provider)
+        using (scope)
+        {
+            var events = scope.ServiceProvider.GetRequiredService<IFactoryEvents>();
+            var collector = scope.ServiceProvider.GetRequiredService<IFactoryEventCollector>();
+
+            await events.Raise(new RelayCollectionEvent("x"), RaiseOptions.ServerOnly);
+
+            Assert.Empty(collector.GetCollectedEvents());
+        }
+    }
+}


### PR DESCRIPTION
First plan of the PHASE arc (phased factory-event dispatch). Adds the phase model and the per-scope deferral queue; **nothing drains yet** — PHASE-003 (stacked behind this) owns the entry-call drain.

## What lands

- `DispatchPhase` enum (`Immediate`/`AfterFlush`/`AfterCommit`), `Immediate` the default and today's exact contract.
- `FactoryEventHandlerAttribute<T>` moved to its own file so `DispatchPhase` is never linked into the netstandard2.0 generator (a duplicated public type broke every project referencing both — recorded as a Discovery Log entry).
- `FactoryEventHandlerRegistry` carries a phase per handler; new 3-arg `RegisterHandler` overload alongside the generator-emitted 2-arg one, both preserving the `[DynamicallyAccessedMembers(All)]` trimming invariant.
- `IFactoryEventPhaseScheduler` (public in `Internal`, so generated code can reach it): enqueue + drain. The drain sweeps the requested phase **and every earlier one**, earliest first, until empty.
- Dispatcher queues non-`Immediate` handlers; log events 9001–9004.

## Gates

Plan review (CONCERNS, 4 vetoes addressed pre-implementation), test review (found a real defect: the drain resolved only the requested phase's queue, silently dropping work enqueued into an already-passed phase — fixed, 3 tests verified red against the pre-fix code), code review. Suites at close: unit 653×2, integration 561×2, Design 86×2 — 0 failures.

Interim-behavior note: three acceptance bullets here pin behavior PHASE-003 is chartered to invert (queue-whenever-a-scheduler-exists). That restatement is pre-declared, not test-gutting — PHASE-003's evidence map lists each amended test with its intent preserved.

Docs: `docs/todos/PHASE-phased-event-dispatch/plans/001-phase-model-and-queueing.md`, reviews in the sibling `reviews/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)