### PR TITLE
PHASE-002: thread the [FactoryEventHandler<T>] phase argument through to registration

### DIFF
--- a/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
@@ -4,8 +4,8 @@
 **Date:** 2026-08-14
 **Related Todo:** [../todo.md](../todo.md)
 **Status:** Draft
-**Last Updated:** 2026-08-14
-**Plan-review opt-in:** No (mechanical pass-through; the API shape was reviewed in PHASE-001)
+**Last Updated:** 2026-08-15
+**Plan-review opt-in:** Yes (adds a generator diagnostic — new compile outcomes for source that builds today; raised from "No" at drafting)
 **Code-review opt-in:** Yes (generator emission change; incremental-cache equality contract at stake)
 
 ---
@@ -17,9 +17,182 @@ and thread it through the relay-handler model into the generated
 `FactoryEventHandlerRegistry.RegisterHandler` call, preserving the incremental-cache
 equality contract on the handler model and the v1.7.0 forwarding-holder trimming pattern.
 Covers generator tests (emitted-source assertions and incremental-cache tracking) for both
-the defaulted and explicit-phase cases. This plan does NOT add runtime behavior (PHASE-001
-owns the runtime) and does NOT touch factory-method emission (PHASE-003).
+the defaulted and explicit-phase cases, plus one end-to-end test proving an
+attribute-declared phased handler actually defers and drains. Also resolves the
+duplicate-same-event-attribute question PHASE-001 deferred here. This plan does NOT add
+runtime behavior (PHASE-001 owns the runtime, PHASE-003 the drain) and does NOT touch
+factory-method emission (PHASE-003).
 
 ---
 
-*(Stub — Intent, Alignment, Constraints, Steps, Acceptance filled at Step 2.)*
+## Intent
+
+- A consumer who writes `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` gets a handler
+  that actually runs at the AfterCommit drain point. Today the argument compiles and is
+  silently ignored: every generated registration lands at `Immediate` no matter what was
+  written. That is the worst available shape — the API reads as working.
+- The attribute becomes the only way a consumer needs to express a phase. Until this plan,
+  phased handlers exist only for code that calls the registry's phase-taking overload by
+  hand, which is not a consumer-facing API.
+- Declaring the same event type twice on one handler class stops being a silent
+  first-registration-wins drop and becomes a compile-time signal.
+
+---
+
+## Framework & Architectural Alignment
+
+- **v1.7.0 forwarding-holder trimming pattern** — registrations stay inside the
+  `NeatooRuntime.IsServerRuntime` guard and the assembly registrar attribute keeps naming
+  the generated holder, never the consumer's handler class.
+- **Incremental-generator cache boundary** — `RelayHandlerModel` and `EventHandlerEntry` are
+  transform outputs whose equality *is* the cache boundary (see their remarks); anything
+  added to them must be value-equatable all the way down.
+- **The generator matches runtime attributes by metadata name and never references the
+  runtime types** — PHASE-001's shared-source discovery: linking `DispatchPhase` into the
+  netstandard2.0 Generator project duplicates a public runtime type in every project that
+  references both. The phase travels through the generator as data.
+- **Relay-handler diagnostics live in the NF05xx range** and follow the severity convention
+  already set by NF0501/NF0502 (structural mistakes are errors) versus NF0503 (a migration
+  warning).
+
+---
+
+## Constraints & Invariants
+
+- Handlers written with no phase argument keep registering at `Immediate`; the existing
+  suite passes unmodified.
+- No `DispatchPhase` type reference inside the Generator project — no new link, no new
+  using, no name-round-trip through the runtime assembly.
+- Registration stays inside the server-runtime guard; nothing new reaches a trimmed client;
+  the registrar attribute keeps naming the generated holder.
+- The `RelayHandler` incremental branch stays cached across an unrelated edit, with the new
+  phase data actually populated on the transform output rather than left at its default.
+- Generated source stays readable — a phase renders as its named enum member, not an
+  opaque numeric cast, for every phase the runtime enum defines.
+- No runtime behavior change in this plan: registry, dispatcher, and scheduler are untouched.
+
+---
+
+## Steps
+
+1. Carry the attribute's phase through the handler transform as data (not as the runtime
+   enum type), defaulting to the `Immediate` value when the consumer wrote no argument.
+2. Keep the transform output value-equatable so the `RelayHandler` branch stays cached.
+3. Emit the phase into the generated registration through the registry's phase-taking
+   overload, rendering the value as its named member so generated code stays readable.
+4. Resolve the deferred duplicate-same-event-attribute question: report a new relay-handler
+   diagnostic rather than let the registry's first-wins dedupe silently drop the second
+   registration. (Severity is the decision this step owns — see Notes.)
+5. Pin emission for the defaulted case, the explicit-phase case, and one class declaring
+   several event types at different phases.
+6. Extend the incremental-cache fixture so the phase data is populated on a transform
+   output, not merely present.
+7. Prove the loop end-to-end: an attribute-declared `AfterCommit` handler — with no
+   hand-written registry call anywhere in the test — defers at raise time and runs at the
+   entry call's drain point.
+
+---
+
+## Acceptance
+
+- [ ] A handler class declaring `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` has its
+      handler deferred at raise time and run when the entry factory call completes, with no
+      hand-written `RegisterHandler` call in the test. `[integration]`
+- [ ] A handler class declaring no phase argument still dispatches at raise time, inside the
+      factory call. `[integration]`
+- [ ] Generated registration for an explicitly phased handler passes the named phase through
+      the phase-taking overload; the defaulted handler registers at `Immediate`. `[unit]`
+- [ ] One handler class declaring several event types at different phases registers each at
+      its own phase. `[unit]`
+- [ ] Declaring the same event type twice on one handler class reports a diagnostic located
+      at the class. `[unit]`
+- [ ] The `RelayHandler` incremental branch stays cached across an unrelated edit while the
+      fixture populates phase data. `[unit]`
+- [ ] Registration remains inside the server-runtime guard and the assembly attribute still
+      names the generated holder. `[unit]`
+- [ ] The existing suite passes unmodified — no test edited to accommodate the new emission.
+      `[explicit-skip: regression meta-bullet, satisfied by the Step 5 full-suite run]`
+- [ ] Build/test green on both target frameworks.
+      `[explicit-skip: meta-bullet, satisfied by the Step 5 gate logs]`
+
+---
+
+## Current State (Pre-Flight)
+
+Walked 2026-08-15, before any edit. No surprise large enough to reshape the plan.
+
+- **The phase is dropped on the floor at exactly one line.** `FactoryGenerator.RelayHandler.cs:48-211`
+  loops `symbol.GetAttributes()` and matches by metadata name (`originalDef.Name ==
+  "FactoryEventHandlerAttribute"`, arity 1, namespace `Neatoo.RemoteFactory`) — exactly the
+  string-matching the attribute's own XML doc promises, so no type reference to remove. It
+  reads `attr.AttributeClass.TypeArguments[0]` for the event type at `:60` and never touches
+  `attr.ConstructorArguments`. That is the whole of the gap.
+- **`EventHandlerEntry`** (`Model/RelayHandlerModel.cs:58-99`) currently carries two strings,
+  two bools, and three `EquatableArray<ParameterModel>`. A phase field has to be a string or
+  an int — `DispatchPhase` is unavailable in the netstandard2.0 generator by design — and
+  either is value-equatable, so the cache contract is satisfied by construction rather than
+  by care.
+- **`RelayHandlerRenderer.RenderServerSideHandler`** (`:126-152`) emits the **two-argument**
+  `RegisterHandler<T>(typeof(C), async (sp, eventObj, options, ct) => …)` inside
+  `if (NeatooRuntime.IsServerRuntime)`. The phase-taking three-argument overload it needs
+  already exists and is public (`FactoryEventHandlerRegistry.cs:56`), with the two-arg form
+  forwarding to it at `Immediate` (`:32-36`) — so PHASE-001 left this leg ready and the
+  emission change is additive.
+- **The duplicate-attribute reasoning holds against the actual matching logic.** The
+  transform matches handler methods by *shape* (first non-`[Service]`, non-CancellationToken
+  parameter of type `T`), not per attribute, so two attributes naming the same `T` resolve to
+  the *same* method; two methods matching one event is NF0502, which reports and adds no
+  entry at all. A duplicate attribute can therefore only ever produce two identical
+  registrations differing in phase — never two distinct handlers. Interim behavior is pinned
+  by `FactoryEventPhaseRegistrationTests.RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration`,
+  whose comment names PHASE-002 as the decider; that test is in-scope to amend.
+- **No existing emission test covers the `RegisterHandler` call.** The Relay Handler region of
+  `AssemblyAttributeEmissionTests.cs` (`:530-700`) pins the assembly attribute, the registrar
+  holder, and compile-cleanliness — the registration line itself is unasserted. The phase
+  assertion is a new assertion class on this leg, not an edit to an existing one. The shared
+  fixture carries a documented NF0502 trap (one handler, one event); a multi-phase fixture
+  must keep event types distinct.
+- **The incremental-cache fixture** (`Core/IncrementalCacheTests.cs`, branch 3) declares two
+  attributes for two distinct event types, both unphased. Phasing one populates the new field
+  without changing entry count or tripping the NF0502 trap the fixture comments warn about.
+- **The end-to-end bullet is reachable.** Attribute-declared handlers already register through
+  the generated registrar in the integration assembly
+  (`TestTargets/Events/FactoryEventHandlerTargets.cs`), and PHASE-003's phase tests live in
+  `Events/Phases/`. The static registry has no test-isolation hook (PHASE-007), so the new
+  phased target needs its own event type — the arc's established workaround.
+- **Emit the phase `global::`-qualified.** PHASE-003's code review (C9) qualified the other
+  generated type references for namespace-shadowing safety; the registration line should match
+  rather than lean on the generated file's `using Neatoo.RemoteFactory;`.
+
+---
+
+## Test Evidence
+
+*(Filled after implementation, before the Step 5 gate.)*
+
+---
+
+## Plan Amendments
+
+*(none yet)*
+
+---
+
+## Notes
+
+- **The duplicate-attribute decision (Step 4).** `[FactoryEventHandler<T>]` is
+  `AllowMultiple = true`, so one class can name the same event twice; the registry dedupes
+  by `(event type, handler class type)` and keeps the first. A duplicate is always a
+  mistake — two distinct handler methods for one event on one class is already the NF0502
+  ambiguous-match error, so the second attribute can never carry its own handler. Drafting
+  toward **Error** severity, matching NF0501/NF0502. The cost is that source which compiles
+  today (with the second attribute silently inert) stops compiling; the benefit is that the
+  silent-loss shape this todo exists to remove does not get a new instance. Flagged for the
+  plan review and for the user.
+- **Undefined enum values.** `[FactoryEventHandler<T>((DispatchPhase)99)]` is expressible.
+  Faithful pass-through renders the cast and the handler then never drains, since the
+  scheduler sweeps only defined phases. Not diagnosing it in this plan — recorded here so
+  the choice is visible rather than accidental.
+- Plan-review opt-in was raised from "No" to "Yes" at drafting: the stub judged this a
+  mechanical pass-through, which the emission work is, but Step 4 changes compile outcomes
+  for existing source and that is a contract change.

--- a/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
@@ -197,7 +197,35 @@ Walked 2026-08-15, before any edit. No surprise large enough to reshape the plan
 
 ## Test Evidence
 
-*(Filled after implementation, before the Step 5 gate.)*
+Unit tests are in `RemoteFactory.UnitTests.FactoryGenerator.AssemblyAttributeEmissionTests`
+(namespace elided below); integration tests in
+`RemoteFactory.IntegrationTests.Events.Phases.FactoryEventPhaseAttributeTests`.
+
+| Acceptance bullet (short) | Tier declared | Test method | Tier confirmed |
+|---|---|---|---|
+| Attribute-declared `AfterCommit` handler defers and drains, no hand-written registration | `[integration]` | `FactoryEventPhaseAttributeTests.RemoteCreate_AttributeDeclaredPhases_GovernWhenHandlersRun` + `.LogicalCreate_…` | ✓ |
+| Handler with no phase argument still dispatches at raise time | `[integration]` | same two tests — the asserted sequence puts `attr-immediate` before `attr-method-done` | ✓ |
+| Explicit phase passes through the phase-taking overload, `global::`-qualified, bare form absent | `[unit]` | `RelayHandler_PhasedHandler_RegistersAtTheDeclaredPhase`; `RelayHandler_PhaseArgument_IsGlobalQualified` (negative pin) | ✓ |
+| Defaulted handler registers at `Immediate` | `[unit]` | `RelayHandler_UnphasedHandler_RegistersAtImmediate` | ✓ |
+| Several event types at different phases each register at their own | `[unit]` | `RelayHandler_SeveralEventTypes_EachRegistersAtItsOwnPhase` | ✓ |
+| Duplicate event type reports a Warning naming the surviving phase, one registration not two | `[unit]` | `RelayHandler_DuplicateEventType_ReportsNF0504AsWarning`; `RelayHandler_DuplicateEventType_EmitsOneRegistrationNotTwo` | ✓ |
+| `RelayHandler` branch stays cached with phase data populated | `[unit]` | `IncrementalCacheTests.UnrelatedEdit_TransformOutputStaysCached("RelayHandler")` — fixture now declares one phased attribute | ✓ (determinism only, by design — see Notes) |
+| Registration stays server-guarded; attribute still names the holder | `[unit]` | `RelayHandler_EmitsAssemblyAttribute`, `RelayHandler_AssemblyAttribute_DoesNotNameConsumerType`, `RelayHandler_RegistrarHolder_ForwardsToUserClass` — pre-existing, unmodified, still green | ✓ |
+| Existing suite passes unmodified | `[explicit-skip]` | Step 5 full-suite run; no existing test's assertions were edited (two comments updated, one fixture attribute phased) | n/a |
+| Build/test green on both TFMs | `[explicit-skip]` | `reviews/002-build.log`, `reviews/002-test.log` | n/a |
+
+Beyond the bullets, three tests pin decisions the plan records rather than acceptance
+signals: `RelayHandler_UndefinedPhaseValue_RendersAsACast` (undefined enum values render
+faithfully), `RelayHandler_DuplicateAfterAFailedFirstDeclaration_RepeatsTheOriginalDiagnostic`
+(the tracker populates on success only, so NF0501/NF0502 emission counts are unchanged), and
+`RelayHandler_PhasedOutput_CompilesWithoutErrors` (the renderer swallows parse failures into a
+comment, so string containment alone can pass on uncompilable source).
+
+**Red-proofing:** all four sharp discriminators verified red against deliberate wrong
+implementations on both TFMs — see [reviews/002-redproof.log](../reviews/002-redproof.log).
+The log also records a first attempt that produced a *false* green (the sabotage failed to
+compile, so the tests ran against the correct generator); build-error counts are checked
+explicitly in every experiment as a result.
 
 ---
 

--- a/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
@@ -52,8 +52,11 @@ factory-method emission (PHASE-003).
   netstandard2.0 Generator project duplicates a public runtime type in every project that
   references both. The phase travels through the generator as data.
 - **Relay-handler diagnostics live in the NF05xx range** and follow the severity convention
-  already set by NF0501/NF0502 (structural mistakes are errors) versus NF0503 (a migration
-  warning).
+  already set by NF0501/NF0502 versus NF0503. The dividing line is what the generator emits,
+  not how wrong the source is: NF0501/NF0502 both add no entry and the class emits no file at
+  all, so the declaration is dead and Error is right; NF0503 fires where the class still works
+  and only a declaration is inert, and Warning was chosen there deliberately to keep the build
+  green (`docs/plans/completed/factory-events-relay-redesign.md:76`).
 
 ---
 
@@ -63,10 +66,19 @@ factory-method emission (PHASE-003).
   suite passes unmodified.
 - No `DispatchPhase` type reference inside the Generator project — no new link, no new
   using, no name-round-trip through the runtime assembly.
+- **The phase travels on the transform output as a primitive `string` or `int` — never a
+  `TypedConstant`, never any `ISymbol`.** Those drag a `Compilation` into the generator's
+  incremental cache, and the caching test cannot see it (see the Notes on what that test
+  actually pins). This one is enforced by code review, not by a test.
+- **The emitted phase is `global::`-qualified.** The unqualified form is the latent bug
+  documented at `RelayHandlerRenderer.cs:38-40`, which shipped for four releases before v1.7.0
+  fixed it on the registrar attribute; this plan emits a new type-bearing token into the same
+  file, bound only by a hardcoded `using`.
 - Registration stays inside the server-runtime guard; nothing new reaches a trimmed client;
-  the registrar attribute keeps naming the generated holder.
-- The `RelayHandler` incremental branch stays cached across an unrelated edit, with the new
-  phase data actually populated on the transform output rather than left at its default.
+  the registrar attribute keeps naming the generated holder. This leg has no positive control
+  in the trimming harness by construction (`RelayHandlerLegTarget.cs:23-31` — the registration
+  is server-guarded, so the harness can only assert absence), so trimming safety here is an
+  argument, not a measurement.
 - Generated source stays readable — a phase renders as its named enum member, not an
   opaque numeric cast, for every phase the runtime enum defines.
 - No runtime behavior change in this plan: registry, dispatcher, and scheduler are untouched.
@@ -81,12 +93,15 @@ factory-method emission (PHASE-003).
 3. Emit the phase into the generated registration through the registry's phase-taking
    overload, rendering the value as its named member so generated code stays readable.
 4. Resolve the deferred duplicate-same-event-attribute question: report a new relay-handler
-   diagnostic rather than let the registry's first-wins dedupe silently drop the second
-   registration. (Severity is the decision this step owns — see Notes.)
+   diagnostic at **Warning**, and skip the duplicate's entry so the emitted registration
+   matches what the diagnostic says. The documented contract already scopes attribute
+   stacking to *several event types* (`docs/attributes-reference.md:222`, skill
+   `factory-events.md:133`) — the diagnostic enforces a rule the docs already state.
 5. Pin emission for the defaulted case, the explicit-phase case, and one class declaring
    several event types at different phases.
-6. Extend the incremental-cache fixture so the phase data is populated on a transform
-   output, not merely present.
+6. Extend the incremental-cache fixture so the phase data is populated on a transform output
+   — for the collection-shaped-field regression it can genuinely catch, not for the phase
+   read, which it cannot (see Notes).
 7. Prove the loop end-to-end: an attribute-declared `AfterCommit` handler — with no
    hand-written registry call anywhere in the test — defers at raise time and runs at the
    entry call's drain point.
@@ -101,13 +116,16 @@ factory-method emission (PHASE-003).
 - [ ] A handler class declaring no phase argument still dispatches at raise time, inside the
       factory call. `[integration]`
 - [ ] Generated registration for an explicitly phased handler passes the named phase through
-      the phase-taking overload; the defaulted handler registers at `Immediate`. `[unit]`
+      the phase-taking overload, `global::`-qualified — the bare `DispatchPhase.X` form is
+      pinned absent, the way `RelayHandler_AssemblyAttribute_DoesNotNameConsumerType` pins the
+      bare registrar argument. The defaulted handler registers at `Immediate`. `[unit]`
 - [ ] One handler class declaring several event types at different phases registers each at
       its own phase. `[unit]`
-- [ ] Declaring the same event type twice on one handler class reports a diagnostic located
-      at the class. `[unit]`
-- [ ] The `RelayHandler` incremental branch stays cached across an unrelated edit while the
-      fixture populates phase data. `[unit]`
+- [ ] Declaring the same event type twice on one handler class reports a Warning located at
+      the class naming the surviving phase, and emits one registration rather than two. `[unit]`
+- [ ] The `RelayHandler` incremental branch stays cached across an unrelated edit, with the
+      fixture populating phase data. Pins determinism and guards a future collection-shaped
+      phase field; it does **not** pin the phase read — see Notes. `[unit]`
 - [ ] Registration remains inside the server-runtime guard and the assembly attribute still
       names the generated holder. `[unit]`
 - [ ] The existing suite passes unmodified — no test edited to accommodate the new emission.
@@ -155,11 +173,22 @@ Walked 2026-08-15, before any edit. No surprise large enough to reshape the plan
 - **The incremental-cache fixture** (`Core/IncrementalCacheTests.cs`, branch 3) declares two
   attributes for two distinct event types, both unphased. Phasing one populates the new field
   without changing entry count or tripping the NF0502 trap the fixture comments warn about.
-- **The end-to-end bullet is reachable.** Attribute-declared handlers already register through
-  the generated registrar in the integration assembly
-  (`TestTargets/Events/FactoryEventHandlerTargets.cs`), and PHASE-003's phase tests live in
-  `Events/Phases/`. The static registry has no test-isolation hook (PHASE-007), so the new
-  phased target needs its own event type — the arc's established workaround.
+- **The end-to-end bullet is reachable**, and the plan review confirmed the preconditions:
+  `NeatooRuntime.IsServerRuntime` defaults true and the integration process never sets the
+  switch, so the generated guard is open in all three containers; registrar discovery is
+  reflective over the assembly attribute (`AddRemoteFactoryServices.cs:171-179`), which every
+  `ClientServerContainers` path triggers. Registration happens with no test-side call — which
+  is what "no hand-written `RegisterHandler`" needs in order to be falsifiable. Three fixture
+  constraints follow and are not optional:
+  - **A brand-new event type.** The phase is baked at first registration, process-wide, for the
+    run — the static registry still has no test-isolation hook (PHASE-007). Reusing any of the
+    events in `FactoryEventPhaseEntryTargets.cs:25-39` or `FactoryEventHandlerTargets.cs` risks
+    `PhaseHandlerRegistrations.EnsureRegistered()` winning the race and pinning the wrong phase.
+  - **The handler class must be `partial`**, or NF0101 fires with an "Execute delegates" message
+    that reads as a non-sequitur here.
+  - Containers are cached per `SerializationFormat` (`ClientServerContainers.cs:146`), so
+    registration happens once per process — deterministic now that the phase comes from
+    generated code rather than a call-order-dependent hand registration.
 - **Emit the phase `global::`-qualified.** PHASE-003's code review (C9) qualified the other
   generated type references for namespace-shadowing safety; the registration line should match
   rather than lean on the generated file's `using Neatoo.RemoteFactory;`.
@@ -180,19 +209,47 @@ Walked 2026-08-15, before any edit. No surprise large enough to reshape the plan
 
 ## Notes
 
-- **The duplicate-attribute decision (Step 4).** `[FactoryEventHandler<T>]` is
-  `AllowMultiple = true`, so one class can name the same event twice; the registry dedupes
-  by `(event type, handler class type)` and keeps the first. A duplicate is always a
-  mistake — two distinct handler methods for one event on one class is already the NF0502
-  ambiguous-match error, so the second attribute can never carry its own handler. Drafting
-  toward **Error** severity, matching NF0501/NF0502. The cost is that source which compiles
-  today (with the second attribute silently inert) stops compiling; the benefit is that the
-  silent-loss shape this todo exists to remove does not get a new instance. Flagged for the
-  plan review and for the user.
+- **The duplicate-attribute decision (Step 4), as settled.** `[FactoryEventHandler<T>]` is
+  `AllowMultiple = true`, so one class can name the same event twice; the registry dedupes by
+  `(event type, handler class type)` and keeps the first. The duplicate can never carry its
+  own handler — the transform's method scan is a pure function of the event type, so both
+  attributes compute the same match set, and two matching methods is already NF0502. Settled
+  at **Warning + skip the duplicate entry**, source order, message naming the surviving phase.
+  Two things this leaves on the record:
+  - *Why not Error.* The severity split in this generator tracks what gets emitted, not how
+    wrong the source is, and a duplicate still produces a working registration. Drafting toward
+    Error mis-applied the plan's own stated taxonomy (plan review A-V1). Warning also keeps
+    source that compiles at v1.7.0 compiling, so this arc stays a minor release.
+  - *Why not last-wins*, which the Discovery Log queued by name: it needs the registry's dedupe
+    key widened — a runtime change in PHASE-001's territory, not this plan's — and it makes the
+    winner depend on registration order, which for multi-assembly consumers is assembly-scan
+    order. Silently picking a winner is the shape this todo exists to remove. Diagnosing is
+    strictly better.
+  - "A duplicate is always a mistake" holds **given the current `(event type, handler class
+    type)` dedupe key**. Widening that key to include phase would make same-class/same-event/
+    two-phase representable, and this diagnostic would have to be revisited.
+- **What the incremental-cache test actually pins.** It asserts equality of two transform
+  outputs across runs, which any deterministic scalar satisfies — including a phase field
+  hardcoded to `Immediate`. And because `ReplaceSyntaxTree` reuses the compilation's reference
+  manager, even a `TypedConstant` field would likely compare equal and stay green. So it is a
+  determinism guard, not a correctness guard, and the primitive-representation rule is a
+  Constraint enforced by code review instead (plan review B-V1). Correctness of the phase read
+  is pinned by the emission and end-to-end bullets, which can go red.
 - **Undefined enum values.** `[FactoryEventHandler<T>((DispatchPhase)99)]` is expressible.
   Faithful pass-through renders the cast and the handler then never drains, since the
-  scheduler sweeps only defined phases. Not diagnosing it in this plan — recorded here so
-  the choice is visible rather than accidental.
-- Plan-review opt-in was raised from "No" to "Yes" at drafting: the stub judged this a
-  mechanical pass-through, which the emission work is, but Step 4 changes compile outcomes
-  for existing source and that is a contract change.
+  scheduler sweeps only defined phases. Not diagnosing it in this plan — recorded here and in
+  the Discovery Log so the choice is visible rather than accidental.
+- **Defaulted handlers emit the three-argument overload too** (plan review B-C5): one renderer
+  path, and the emission test then pins `Immediate` positively rather than pinning an absence.
+  Consequence: the two-argument `RegisterHandler` overload keeps zero generated call sites. It
+  stays — it is public API and consumers may call it.
+- **A new descriptor needs its `GetDescriptor` switch case** (`FactoryGenerator.cs:150-158`),
+  whose default arm throws. Miss it and the first duplicate attribute crashes the generator
+  instead of reporting.
+- `FactoryEventPhaseRegistrationTests.RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration`
+  needs a comment update only. Its assertion exercises the registry API directly, which the
+  generator diagnostic cannot reach, so the pinned behavior is unchanged.
+- Plan-review opt-in was raised from "No" to "Yes" at drafting, on the strength of Step 4 being
+  a contract change. The review returned three vetoes, none of them about Step 4's mechanics —
+  worth remembering that the opt-in earned its keep for a reason other than the one that
+  triggered it.

--- a/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
@@ -260,6 +260,21 @@ explicitly in every experiment as a result.
   from the bare one.
 - **Discovery Log link:** 2026-08-15 — PHASE-002 (a third "can't go red" bullet)
 
+### 2026-08-15 — `DiagnosticTestHelper` double-count fixed here rather than in plan 008
+
+- **Section affected:** Scope (widened), Test Evidence
+- **Original said:** The helper defect was routed to the new tech-debt plan 008.
+- **What changed:** Fixed in this plan at the user's direction. `RunGenerator` no longer
+  concatenates the driver's out-param with `GetRunResult().Diagnostics` — the same set twice.
+  Three harness tests added (`DiagnosticTestHelperTests`), and the five NF0504/NF0502 tests
+  that had been reading `runResult.Diagnostics` to route around the doubling now use the
+  returned array.
+- **Why:** No caller counted, so nothing was red, but the natural assertion was wrong in a way
+  that reads as a product bug — which is how it presented when NF0504's test asserted
+  `Single()` and got two. Red-proofed (RP-7); the accompanying RP-8 disproved the stated
+  rationale for *how* it was fixed and the comments were corrected.
+- **Discovery Log link:** 2026-08-15 — PHASE-002 (a red-proof that disproved its own premise)
+
 ### 2026-08-15 — Gate round: five tests added, four code fixes
 
 - **Section affected:** Test Evidence, Notes

--- a/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/002-generator-phase-passthrough.md
@@ -3,7 +3,7 @@
 **Plan #:** 002
 **Date:** 2026-08-14
 **Related Todo:** [../todo.md](../todo.md)
-**Status:** Draft
+**Status:** Done
 **Last Updated:** 2026-08-15
 **Plan-review opt-in:** Yes (adds a generator diagnostic — new compile outcomes for source that builds today; raised from "No" at drafting)
 **Code-review opt-in:** Yes (generator emission change; incremental-cache equality contract at stake)
@@ -110,27 +110,27 @@ factory-method emission (PHASE-003).
 
 ## Acceptance
 
-- [ ] A handler class declaring `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` has its
+- [x] A handler class declaring `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` has its
       handler deferred at raise time and run when the entry factory call completes, with no
       hand-written `RegisterHandler` call in the test. `[integration]`
-- [ ] A handler class declaring no phase argument still dispatches at raise time, inside the
+- [x] A handler class declaring no phase argument still dispatches at raise time, inside the
       factory call. `[integration]`
-- [ ] Generated registration for an explicitly phased handler passes the named phase through
+- [x] Generated registration for an explicitly phased handler passes the named phase through
       the phase-taking overload, `global::`-qualified — the bare `DispatchPhase.X` form is
       pinned absent, the way `RelayHandler_AssemblyAttribute_DoesNotNameConsumerType` pins the
       bare registrar argument. The defaulted handler registers at `Immediate`. `[unit]`
-- [ ] One handler class declaring several event types at different phases registers each at
+- [x] One handler class declaring several event types at different phases registers each at
       its own phase. `[unit]`
-- [ ] Declaring the same event type twice on one handler class reports a Warning located at
+- [x] Declaring the same event type twice on one handler class reports a Warning located at
       the class naming the surviving phase, and emits one registration rather than two. `[unit]`
-- [ ] The `RelayHandler` incremental branch stays cached across an unrelated edit, with the
+- [x] The `RelayHandler` incremental branch stays cached across an unrelated edit, with the
       fixture populating phase data. Pins determinism and guards a future collection-shaped
       phase field; it does **not** pin the phase read — see Notes. `[unit]`
-- [ ] Registration remains inside the server-runtime guard and the assembly attribute still
+- [x] Registration remains inside the server-runtime guard and the assembly attribute still
       names the generated holder. `[unit]`
-- [ ] The existing suite passes unmodified — no test edited to accommodate the new emission.
+- [x] The existing suite passes unmodified — no test edited to accommodate the new emission.
       `[explicit-skip: regression meta-bullet, satisfied by the Step 5 full-suite run]`
-- [ ] Build/test green on both target frameworks.
+- [x] Build/test green on both target frameworks.
       `[explicit-skip: meta-bullet, satisfied by the Step 5 gate logs]`
 
 ---
@@ -208,9 +208,9 @@ Unit tests are in `RemoteFactory.UnitTests.FactoryGenerator.AssemblyAttributeEmi
 | Explicit phase passes through the phase-taking overload, `global::`-qualified, bare form absent | `[unit]` | `RelayHandler_PhasedHandler_RegistersAtTheDeclaredPhase`; `RelayHandler_PhaseArgument_IsGlobalQualified` (negative pin) | ✓ |
 | Defaulted handler registers at `Immediate` | `[unit]` | `RelayHandler_UnphasedHandler_RegistersAtImmediate` | ✓ |
 | Several event types at different phases each register at their own | `[unit]` | `RelayHandler_SeveralEventTypes_EachRegistersAtItsOwnPhase` | ✓ |
-| Duplicate event type reports a Warning naming the surviving phase, one registration not two | `[unit]` | `RelayHandler_DuplicateEventType_ReportsNF0504AsWarning`; `RelayHandler_DuplicateEventType_EmitsOneRegistrationNotTwo` | ✓ |
-| `RelayHandler` branch stays cached with phase data populated | `[unit]` | `IncrementalCacheTests.UnrelatedEdit_TransformOutputStaysCached("RelayHandler")` — fixture now declares one phased attribute | ✓ (determinism only, by design — see Notes) |
-| Registration stays server-guarded; attribute still names the holder | `[unit]` | `RelayHandler_EmitsAssemblyAttribute`, `RelayHandler_AssemblyAttribute_DoesNotNameConsumerType`, `RelayHandler_RegistrarHolder_ForwardsToUserClass` — pre-existing, unmodified, still green | ✓ |
+| Duplicate event type reports a Warning at the class naming the surviving phase, one registration not two | `[unit]` | `RelayHandler_DuplicateEventType_ReportsNF0504AsWarning`; `…_PhasedFirst_KeepsThatPhaseAndNamesItInTheMessage` (the discriminating one); `…_DiagnosticIsLocatedAtTheClass`; `…_EmitsOneRegistrationNotTwo` | ✓ |
+| `RelayHandler` branch stays cached with phase data populated | `[unit]` | `IncrementalCacheTests.UnrelatedEdit_TransformOutputStaysCached("RelayHandler")` — fixture now declares one phased attribute, and `IncrementalCacheTests.Fixture_PopulatesThePhaseArgument` pins that the argument still binds | ✓ (determinism only, by design — see Notes) |
+| Registration stays server-guarded; attribute still names the holder | `[unit]` | `RelayHandler_PhasedRegistration_StaysInsideTheServerRuntimeGuard` (**new** — the guard half had no unit assertion at all before the gate caught it); `RelayHandler_EmitsAssemblyAttribute`, `…_DoesNotNameConsumerType`, `…_RegistrarHolder_ForwardsToUserClass` for the holder half — pre-existing, unmodified, still green | ✓ |
 | Existing suite passes unmodified | `[explicit-skip]` | Step 5 full-suite run; no existing test's assertions were edited (two comments updated, one fixture attribute phased) | n/a |
 | Build/test green on both TFMs | `[explicit-skip]` | `reviews/002-build.log`, `reviews/002-test.log` | n/a |
 
@@ -231,7 +231,48 @@ explicitly in every experiment as a result.
 
 ## Plan Amendments
 
-*(none yet)*
+### 2026-08-15 — Duplicate diagnostic: Warning, and the duplicate's entry is skipped
+
+- **Section affected:** Step 4, Framework Alignment, Notes
+- **Original said:** Report the duplicate at Error, matching NF0501/NF0502.
+- **What changed:** Warning, paired with skipping the duplicate's entry at emission.
+- **Why:** Plan review A-V1 found the project's documented precedent — NF0503 chose Warning
+  explicitly to keep the build green for the identical shape — and showed the draft had
+  mis-applied its own stated taxonomy. The dividing line is what the generator emits: a
+  duplicate still produces a working registration. Skipping the entry is what keeps Warning
+  honest (B-C3), otherwise two registrations at different phases would reintroduce the silent
+  loss under a diagnostic saying "the duplicate is ignored".
+- **Discovery Log link:** 2026-08-15 — PHASE-002 (plan review: the duplicate-attribute
+  severity, settled)
+
+### 2026-08-15 — Two acceptance bullets reworded so they can fail
+
+- **Section affected:** Acceptance, Constraints
+- **Original said:** The cache bullet claimed the branch stays cached "with the new phase data
+  actually populated"; the emission bullet claimed the named phase passes through.
+- **What changed:** The cache bullet now claims determinism plus future collection-shaped-field
+  coverage only, with the primitive-representation rule moved to a Constraint enforced by code
+  review; the emission bullet requires the `global::`-qualified form with a negative pin on the
+  bare one.
+- **Why:** Plan review B-V1 and B-V2 — neither bullet could go red for what it claimed. The
+  cache test compares transform outputs across runs sharing a reference manager; a scalar is
+  equal either way, and `Contains("DispatchPhase.AfterCommit")` cannot tell the qualified form
+  from the bare one.
+- **Discovery Log link:** 2026-08-15 — PHASE-002 (a third "can't go red" bullet)
+
+### 2026-08-15 — Gate round: five tests added, four code fixes
+
+- **Section affected:** Test Evidence, Notes
+- **Original said:** Nine tests covered the acceptance surface.
+- **What changed:** Added the phased-first duplicate test (the discriminating one), the
+  server-runtime-guard assertion, the NF0504 location pin, the cache-fixture binding pin, and
+  a negative value in the undefined-phase theory. Code fixes: `InvariantCulture` on both
+  numeric-to-string paths, `is int` patterns replacing `Convert.ToInt32`, a misplaced XML doc
+  restored, and NF0504's row added to `CLAUDE-DESIGN.md`.
+- **Why:** Test review (4 should-cover) and code review (V1 + C1/C2/C3/C6), which independently
+  converged on the unfalsifiable NF0504 message assertion.
+- **Discovery Log link:** 2026-08-15 — PHASE-002 (both gates found the same unfalsifiable
+  assertion)
 
 ---
 

--- a/docs/todos/PHASE-phased-event-dispatch/plans/004-afterflush-coordinator.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/004-afterflush-coordinator.md
@@ -49,4 +49,18 @@ coordinator is a drain trigger, nothing more.
   is in-transaction and consumer-invoked, so it takes the consumer's token — the two
   drain points deliberately differ.
 
+---
+
+## Inherited from PHASE-002 (recorded at its Step 5 gates)
+
+- **`AfterFlush` is already consumer-reachable, and already fail-opens — silently.** PHASE-002
+  made the attribute's phase argument real, so `[FactoryEventHandler<T>(DispatchPhase.AfterFlush)]`
+  works today and the scheduler's sweep drains it at the AfterCommit entry point. What is
+  missing is only AC-5's logged warning. Acceptance here must cover an **attribute-declared**
+  AfterFlush handler, not only one registered through the registry's 3-arg overload — the
+  consumer-facing path is otherwise untested end to end.
+- NF0504 (Warning) now fires when one class declares the same event type twice, and the
+  duplicate's entry is skipped. If this plan widens the registry's `(event type, handler class
+  type)` dedupe key for any reason, that diagnostic's premise changes and it must be revisited.
+
 *(Stub — Intent, Alignment, remaining Constraints, Steps, Acceptance filled at Step 2.)*

--- a/docs/todos/PHASE-phased-event-dispatch/plans/005-design-docs-skill.md
+++ b/docs/todos/PHASE-phased-event-dispatch/plans/005-design-docs-skill.md
@@ -22,4 +22,29 @@ NOT change any behavior.
 
 ---
 
+## Inherited from PHASE-002 (recorded at its plan review)
+
+PHASE-002 is the plan that makes the attribute's phase real, so these anchors go stale the
+day it lands. They are listed concretely because the stub's "document the phase contract"
+would not have found them:
+
+- **Prose that becomes conditionally false** — it describes every handler the way only an
+  `Immediate` handler now behaves:
+  - `docs/attributes-reference.md:218` — "Runs in the caller's DI scope … triggered by
+    `IFactoryEvents.Raise` during a factory method. All handlers … sharing the caller's
+    `DbContext` and transaction. A throwing handler aborts the chain and propagates to the
+    caller." All three clauses are false for an `AfterCommit` handler.
+  - `skills/RemoteFactory/references/factory-events.md:115` — "All of them run in the caller's
+    scope, sequentially, in unspecified order, **before `Raise` returns**."
+- **Diagnostics tables needing the new duplicate-attribute row (NF05xx, Warning):**
+  `docs/factory-events.md:370-372`, `skills/RemoteFactory/references/factory-events.md:541-543`,
+  `docs/attributes-reference.md:202`.
+- **Contract prose worth tightening rather than replacing:** `docs/attributes-reference.md:222`
+  and skill `factory-events.md:133` already scope attribute stacking to *several event types* —
+  which is the documented basis PHASE-002's diagnostic enforces. Say so explicitly.
+- Also inherited from PHASE-003: document "one factory call per scope at a time" as the
+  concurrency guidance, and the sync block-drain deadlock caveat.
+
+---
+
 *(Stub — Intent, Alignment, Constraints, Steps, Acceptance filled at Step 2.)*

--- a/docs/todos/PHASE-phased-event-dispatch/reviews/002-code-review.md
+++ b/docs/todos/PHASE-phased-event-dispatch/reviews/002-code-review.md
@@ -1,0 +1,62 @@
+# PHASE-002 — Code Review (per-plan, findings-only)
+
+**Date:** 2026-08-15
+**Reviewer:** `code-reviewer`
+**Result:** 1 veto-tier, 8 callout-tier
+**Disposition:** veto closed; 5 callouts fixed; 3 recorded or routed.
+
+---
+
+## Veto-tier
+
+### V1 — The NF0504 message test cannot go red for the claim its bullet makes
+
+The severity test stacks the **unphased** attribute first, so the surviving phase is
+`Immediate` — which is simultaneously the hardcoded default constant, the value the
+malformed-argument fallback returns, and what a `messageFormat` with the `{2}` placeholder
+deleted would print. The assertion stays green against all three wrong implementations, and
+the `phaseName.Length > 0 ? phaseName : phaseValue.ToString(…)` expression that computes the
+argument had both branches uncovered in the non-default direction.
+
+Veto-tier by this arc's own standard rather than a generic one: plan review B-V2 vetoed a
+planned `Contains("DispatchPhase.AfterCommit")` for exactly this reason, B-V1 vetoed the cache
+bullet for it, and it is the one claim in the plan that was neither pinned nor declared
+unpinnable in the red-proof log.
+
+**Closed.** `RelayHandler_DuplicateEventType_PhasedFirst_KeepsThatPhaseAndNamesItInTheMessage`
+asserts the message names `AfterCommit`, that it does *not* name `Immediate`, and that the
+emitted registration matches — pinning source-order-wins at the same time. Red-proofed by
+hardcoding `Immediate` into the `messageFormat` (RP-5): the new test goes red, the original
+stays green, which is the diagnosis confirmed. The test-review gate reached the same finding
+independently.
+
+---
+
+## Callout-tier
+
+| # | Finding | Disposition |
+|---|---|---|
+| C1 | **Culture-sensitive integer rendering into generated C#.** Interpolation formats with `CurrentCulture`; `(DispatchPhase)(-1)` compiles, and on a culture whose negative sign is not ASCII `-` (sv-SE resolves to U+2212 under ICU) the emitted argument is a CS1056 in the consumer's build. The file already passed `InvariantCulture` to both `Convert.ToInt32` calls, where culture cannot matter, and omitted it from the two `ToString()` paths, where it can. | **Fixed** — `InvariantCulture` on both; `RelayHandler_UndefinedPhaseValue_RendersAsACast` is now a `[Theory]` covering a negative value. |
+| C2 | **Misplaced XML doc.** `ReadDispatchPhase` was inserted between `TransformRelayHandler`'s doc comment and its method, leaving `ReadDispatchPhase` with two `<summary>` blocks and the file's central transform undocumented. No compiler warning fires for a duplicate `<summary>`. | **Fixed** — doc restored to `TransformRelayHandler`. |
+| C3 | **`Convert.ToInt32` can throw inside a transform**, which surfaces as CS8785 and takes down every generated file in the compilation, not just this one. No compiling shape is known to reach it, but the repo already has a non-throwing idiom for reading attribute constructor arguments. | **Fixed** — `is int` pattern matches in both places, matching `FactoryGenerator.cs:226`. Zero behavior change for compiling source; the crash class is gone. |
+| C4 | **NF0503's emission count changes in one shape** — a class with a duplicate attribute *and* a matching instance method now emits NF0503 once instead of twice, because the duplicate short-circuits before the instance-method scan. An improvement, but the plan's reasoning named only NF0501/NF0502 as held steady. | **Recorded** in the transform's comment. One warning per class beats one per redundant attribute. |
+| C5 | **NF0504 repeats verbatim for a triple declaration**, all at the class location. `ApplicationSyntaxReference` would let it point at the redundant attribute itself. | **Accepted with the reason recorded** — NF0501/NF0502 both use the class location, so this is convention-consistent. The location clause is now pinned (test-review #3). |
+| C6 | **`CLAUDE-DESIGN.md` is going stale and PHASE-005's handoff did not name it.** The arc's practice is to maintain that file in-plan — PHASE-003 updated its log-id rows inside its own plan. | **Fixed here** — NF0504 added to the diagnostics table and the prose line, plus a line stating the attribute's phase now reaches registration. |
+| C7 | **Attributes split across partial declarations** — `ForAttributeWithMetadataName` fires per syntax node while the transform reads `symbol.GetAttributes()`, so two attributed partials should collide on hint name. Pre-existing; flagged because Step 4 settled the attribute-stacking contract and this is the stacking shape that reasoning does not reach. Inferred, not measured. | **Routed** to new tech-debt plan 008 (both reviewers advised against widening PHASE-007). |
+| C8 | Container state — plan `Status: Draft`, Index row `Draft`, checkboxes unchecked. | **Closed at Step 6.** |
+
+## Verified clean (the load-bearing claims)
+
+- **Constraint 1, primitive representation** — the constraint the plan said review must enforce
+  because no test can. `PhaseName`/`PhaseValue` are `string`/`int`; the `TypedConstant` and
+  `IFieldSymbol` stay local to `ReadDispatchPhase`; `registeredPhaseByEventType` is a local
+  dictionary discarded at transform end; `DiagnosticInfo.MessageArgs` is `EquatableArray<string>`,
+  so the new message args do not leak either. No `ISymbol`, `TypedConstant`, or `Compilation`
+  reaches the transform output, directly or transitively.
+- **Trimming shapes** — registration still inside `if (NeatooRuntime.IsServerRuntime)`; assembly
+  attribute still names the generated holder; an enum constant lowers to `ldc.i4.<n>` so no new
+  type reference reaches the client; DAM annotation present on both overloads.
+- **NF0504 × NF0501/NF0502 orderings** — walked exhaustively; the counts hold for every ordering.
+  The one exception is C4.
+- **Test Evidence honesty** — every cited test exists at the declared tier and location; the only
+  edits to pre-existing test files are two comment blocks and one fixture attribute.

--- a/docs/todos/PHASE-phased-event-dispatch/reviews/002-plan-review.md
+++ b/docs/todos/PHASE-phased-event-dispatch/reviews/002-plan-review.md
@@ -1,0 +1,123 @@
+# PHASE-002 — Plan Review
+
+**Date:** 2026-08-15
+**Reviewer:** `plan-reviewer` (Pass A: documented requirements; Pass B: codebase)
+**Verdict:** CONCERNS — 3 veto-tier, 12 callout-tier
+**Disposition:** all 3 vetoes addressed in the draft before implementation; callouts addressed
+or explicitly declined below.
+
+---
+
+## Veto-tier
+
+### A-V1 — Error severity contradicts this project's own precedent for the identical shape
+
+The reviewer found the documented decision for NF0503 in
+`docs/plans/completed/factory-events-relay-redesign.md:76` — Warning was chosen *explicitly*
+because it "makes the migration footgun loud at compile time without breaking the build",
+for the same problem shape: a declaration that compiles and is silently inert.
+
+And the plan's own taxonomy, correctly stated in Framework Alignment, puts duplicates on the
+Warning side. Verified against the transform: NF0501/NF0502 both `continue` **without adding
+an entry**, and `FactoryGenerator.cs:100` returns early at `Entries.Count == 0` — the class
+emits no file at all, so the declaration is 100% dead and Error is right. A duplicate
+same-event attribute is different in kind: the handler is found, the entry is added, the
+registration emits and works. Only the second attribute is redundant.
+
+**Disposition: ADOPTED — severity is Warning.** The draft's Error was a mis-application of a
+taxonomy the draft itself had written down correctly. Warning also dissolves A-C3 (no
+breaking change, no major-version question) at no cost to the signal.
+
+Consequence, from B-C3: Warning alone would *reintroduce* the silent loss — two attributes at
+different phases would emit two registrations and the registry's first-wins dedupe would pick
+one silently. So Warning is paired with **skipping the duplicate entry at emission**, in
+source order, with the surviving phase named in the diagnostic message. The generator's output
+then matches what the diagnostic says.
+
+### B-V1 — The incremental-cache Acceptance bullet cannot go red for what the plan claimed
+
+`DiagnosticTestHelper.RunGeneratorTracked` re-parses into the same path and calls
+`ReplaceSyntaxTree`, so the transform genuinely re-runs — the guard is not `Cached`-vacuous.
+But what it asserts is *equality of two transform outputs across runs*, and a scalar phase
+field is equal across runs whether the generator reads the attribute correctly, reads it
+wrong, or hardcodes `Immediate`. It is a determinism check, not a correctness check.
+
+Worse for the stated purpose: `ReplaceSyntaxTree` reuses the compilation's reference manager,
+so even the genuinely bad representation — storing the raw `TypedConstant` — would likely
+compare equal and stay green while rooting a `Compilation` in the generator cache.
+
+This is the `MEMORY.md` "verify, don't inherit" failure mode verbatim, in a plan written by
+someone who has that memory loaded. Second time this arc.
+
+**Disposition: ADOPTED, options (a) + (c).** The coverage claim is dropped rather than
+propped up:
+
+- The Acceptance bullet is reworded to claim only what the test pins — the branch stays
+  cached, with the fixture now populating phase data so a *future collection-shaped* phase
+  field would be covered. It no longer pretends to pin the phase read.
+- The primitive-representation rule moves into Constraints as a code-review item, restated
+  per B-C4 to forbid the thing that actually hurts.
+- Correctness of the phase read is pinned where it can genuinely go red: the emission bullets
+  and the end-to-end bullet.
+
+Option (b) — two independently constructed compilations to get distinct reference managers —
+was considered and declined. The generator's model types are `internal`, so a test cannot
+compare models directly; the reachable cross-driver comparison is generated *source text*,
+which is another determinism check and would not catch a `TypedConstant` field either. Buying
+a second non-discriminating test to replace a non-discriminating claim is the failure mode,
+not the fix.
+
+### B-V2 — Missing `global::` invariant on the newly emitted type token
+
+`RelayHandlerRenderer.cs:38-40` documents that the unqualified form was a latent bug that
+shipped for four releases, and line 608 of the emission tests now pins its absence. This plan
+emits a *new* type-bearing token into the same file, bound only by a hardcoded
+`using Neatoo.RemoteFactory;`. The draft's constraint ("named enum member, not an opaque
+numeric cast") is satisfied by the unqualified form, so nothing steers; and the draft's
+acceptance bullet would be satisfied by a `Contains("DispatchPhase.AfterCommit")` that cannot
+tell the two apart. Third "can't go red" in one plan.
+
+**Disposition: ADOPTED.** The pre-flight had already spotted the qualification (Current State,
+last bullet) but left it as an observation with nothing enforcing it — which is exactly how it
+would have been lost. Now a Constraint, with the Acceptance bullet worded to require pinning
+the qualified form plus a negative pin on the bare form, mirroring line 608.
+
+---
+
+## Callout-tier
+
+| # | Finding | Disposition |
+|---|---|---|
+| A-C1 | Cite the documented "several event **types**" contract as the basis for Step 4 | Adopted — `docs/attributes-reference.md:222`, skill `factory-events.md:133` cited in Step 4 |
+| A-C2 | PHASE-005 doesn't name the prose this plan invalidates, nor the diagnostics tables | Adopted — anchors handed to PHASE-005's stub; Discovery Log entry |
+| A-C3 | If Error, classify against the version-impact table (breaking → major) | Moot — Warning chosen |
+| B-C1 | "Always a mistake" holds *given the current dedupe key*, not absolutely | Adopted — stated in Notes |
+| B-C2 | Step 4 never names last-wins, which the Discovery Log queued by name | Adopted — rejection recorded in Notes |
+| B-C3 | Warning also requires deciding whether the duplicate entry still emits | Adopted — folded into A-V1's disposition; entry is skipped |
+| B-C4 | Representation constraint forbids the wrong thing | Adopted — restated as primitive `string`/`int`, never `TypedConstant`, never `ISymbol` |
+| B-C5 | 2-arg vs 3-arg overload for the defaulted case is undecided | Adopted — 3-arg universally; consequence noted (2-arg keeps zero generated call sites) |
+| B-C6 | End-to-end fixture constraints (new event type, `partial`, no overlap) | Adopted — recorded in Current State |
+| B-C7 | Trimming safety here is an argument, not a measurement | Adopted — stated in Constraints |
+| B-C8 | New descriptor needs a `GetDescriptor` switch case or the generator throws | Adopted — Notes |
+| B-C9 | Fixture extension is safe while diagnostic-free | Noted, no action |
+| B-C10 | `RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration` comment needs updating | Adopted — comment-only; the test's assertion stands untouched (it exercises the registry API, which the generator diagnostic cannot reach) |
+| Index | Undefined-enum-value decision lives only in plan Notes | Adopted — promoted to the Discovery Log |
+
+---
+
+## Reviewer answers to the questions posed
+
+- **Q2 (is the duplicate reasoning true?)** Verified against the transform's matching logic —
+  the scan is a pure function of the event type and does not know which attribute instance is
+  being processed, so two attributes naming the same `T` compute an identical match set. No
+  legitimate shape found: aliased generic arguments collapse to the same fully-qualified
+  string and *are* genuine duplicates; closed generics over different arguments are correctly
+  not duplicates; `Inherited = false` rules out base-class interaction; `#if` leaves one.
+- **Q3 (is the end-to-end bullet reachable?)** Yes. `NeatooRuntime.IsServerRuntime` defaults
+  true and the integration process never sets the switch, so the generated guard is open in
+  all three containers; registrar discovery is reflective over the assembly attribute, which
+  every `ClientServerContainers` path triggers. Registration happens with no test-side call —
+  which is what the bullet's falsifiability condition needs.
+- **Q4 (trimming)** No missed implication. An enum value lowers to `ldc.i4.<n>` — no new type
+  reference, no new DAM surface; the DAM annotation is on both overloads. But the leg has no
+  positive control by construction, so this is an argument, not a measurement (→ B-C7).

--- a/docs/todos/PHASE-phased-event-dispatch/reviews/002-test-review.md
+++ b/docs/todos/PHASE-phased-event-dispatch/reviews/002-test-review.md
@@ -1,0 +1,64 @@
+# PHASE-002 — Test Review (Step 5 Gate)
+
+**Date:** 2026-08-15
+**Reviewer:** `test-reviewer`
+**Result:** no must-cover; 4 should-cover (all plan-related), 5 nice-to-have, 4 tech-debt
+**Disposition:** all 4 should-cover closed; 2 of 5 nice-to-have closed; tech-debt routed.
+
+The gate verified the test-count delta against PHASE-003's log (668 unit / 579 integration →
+677 / 581) to confirm nothing had been deleted, and independently re-derived the end-to-end
+tests' falsifiability rather than taking it from the plan — confirming no `RegisterHandler`
+call exists in the new targets or tests, that the generated file emits the AfterCommit
+registration, and that the two new event types appear nowhere else in `src/`.
+
+---
+
+## Should-cover — all closed
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | **The server-runtime guard on the relay leg had no assertion anywhere in the unit suite**, and the evidence row claimed ✓ from three tests that assert only the assembly-attribute/holder half. The only real control was the CI publish-trimmed absence gate — reasoned from marker reachability, not in the Step 5 logs. | Closed — `RelayHandler_PhasedRegistration_StaysInsideTheServerRuntimeGuard` asserts guard-then-registration *in order*; red-proofed (RP-6). Evidence row now cites it. |
+| 2 | **NF0504's "names the surviving phase" only exercised where the survivor is `Immediate`** — which is also the hardcoded default, the malformed-argument fallback, and what a deleted placeholder prints. Green against three wrong implementations. | Closed — `RelayHandler_DuplicateEventType_PhasedFirst_KeepsThatPhaseAndNamesItInTheMessage`; red-proofed (RP-5). Also pins source-order-wins, which nothing else did. Independently raised as code review V1. |
+| 3 | **NF0504's location unasserted** while the Acceptance bullet says "located at the class". | Closed — `RelayHandler_DuplicateEventType_DiagnosticIsLocatedAtTheClass`, asserting through the source span rather than a line/column pair so a fixture edit cannot make it a false red. |
+| 4 | **The incremental-cache fixture's phase argument can silently stop binding** — the transform's malformed-argument fallback returns `Immediate`, `RunGeneratorTracked` never checks the input compilation for CS errors, and `Fixture_ProducesNoDiagnostics` filters `NF` ids only. The fixture would degrade to two defaulted attributes with every test still green. | Closed — `IncrementalCacheTests.Fixture_PopulatesThePhaseArgument`, the file's third fixture-health guard. |
+
+## Nice-to-have
+
+| Finding | Disposition |
+|---|---|
+| `AfterFlush` never rendered in any emission test | Closed — third event type added to `PhasedRelayHandlerSource` at `AfterFlush` |
+| Phase + `[Service]` + `CancellationToken` not pinned at emission | Closed — the same new handler carries both, so the phase token and the parameter list are pinned interacting |
+| Duplicate variants: triple declaration, undefined-cast survivor, aliased generics | Declined for this plan — the aliased-generics case is reasoned in the plan review; the others are low-value permutations |
+| NF0503 emission count changes in one shape | Recorded in the transform's comment (code review C4), no test |
+| NF0504 tests live in `AssemblyAttributeEmissionTests` rather than the NF05xx diagnostics file | Accepted — they assert emission alongside the diagnostic, which is what that file is for |
+
+## Tech debt routed
+
+Both reviewers agreed **not** to widen PHASE-007 (already three unrelated items). New plan 008:
+
+- The **event-type token** in the emitted registration is not `global::`-qualified — the same
+  hazard this plan spent a Constraint, a veto, and a negative pin on, three tokens to the left
+  in the same statement. Note the ratchet: five new assertions hardcode the unqualified form.
+- **Attributes split across partial declarations** — `ForAttributeWithMetadataName` fires per
+  syntax node while the transform reads `symbol.GetAttributes()`, so two attributed partials
+  should produce duplicate hint names. Inferred from reading, not measured.
+- `DiagnosticTestHelper.RunGenerator` **returns every generator diagnostic twice** (driver
+  out-param concatenated with `runResult.Diagnostics`). No current test makes a count
+  assertion, so nothing is wrong today; it is a live trap. Found while writing these tests.
+- `RunGeneratorTracked` never checks the input compilation for CS errors — the enabler for
+  should-cover #4, and it applies to every future cache fixture.
+- `Diagnostics/NF04xxFactoryEventHandlerTests.cs` contains `class NF05xxFactoryEventHandlerTests`.
+
+## Handoff to PHASE-004
+
+As of this plan, `[FactoryEventHandler<T>(DispatchPhase.AfterFlush)]` is consumer-reachable
+for the first time, and the scheduler's sweep already drains it at the AfterCommit entry
+point — fail-open *without* the logged warning PHASE-004 promises. PHASE-004's acceptance
+should cover an **attribute-declared** AfterFlush handler, not only a hand-registered one.
+Recorded in the Discovery Log and in PHASE-004's inherited section.
+
+## Sacred tests
+
+Verified unweakened. `RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration` —
+comment rewrite only, four statements byte-identical. `IncrementalCacheTests` fixture — one
+attribute gained a phase argument, no assertion changed, NF0502-trap avoidance preserved.

--- a/docs/todos/PHASE-phased-event-dispatch/todo.md
+++ b/docs/todos/PHASE-phased-event-dispatch/todo.md
@@ -71,16 +71,66 @@ exposes drain points.
 | # | File | Title | Status |
 |---|------|-------|--------|
 | 001 | [001-phase-model-and-queueing](./plans/001-phase-model-and-queueing.md) | DispatchPhase enum, registry phase, dispatcher queueing | Done |
-| 002 | [002-generator-phase-passthrough](./plans/002-generator-phase-passthrough.md) | Generator reads phase from attribute, threads to registration | Draft |
+| 002 | [002-generator-phase-passthrough](./plans/002-generator-phase-passthrough.md) | Generator reads phase from attribute, threads to registration | Done |
 | 003 | [003-aftercommit-entry-call-drain](./plans/003-aftercommit-entry-call-drain.md) | Entry-call tracking in generated factories; AfterCommit drain | Done |
 | 004 | [004-afterflush-coordinator](./plans/004-afterflush-coordinator.md) | IFactoryEventPhaseCoordinator public API + fallback drain | Draft |
 | 005 | [005-design-docs-skill](./plans/005-design-docs-skill.md) | Design projects, published docs, skill reference | Draft |
 | 006 | [006-coalescing](./plans/006-coalescing.md) | Opt-in same-event coalescing (v2, queued per user) | Draft |
 | 007 | *(not yet drafted)* | Tech debt: registry test-isolation hook (`Clear()` is internal and uncalled; every test invents unique event types); 9002/9004/9006 positive emission pins; `ClientServerContainers` tuple-order divergence + `ScopesWithLogging` duplication | Draft |
+| 008 | *(not yet drafted)* | Generator emission hygiene: `global::`-qualify the remaining emitted type tokens (event type in relay registration, and audit the other legs); probe the partial-declaration attribute-split hint-name collision; `DiagnosticTestHelper` returns every generator diagnostic twice and `RunGeneratorTracked` never checks the input compilation for CS errors; `NF04xx…Tests.cs` holds `class NF05xx…Tests` | Draft |
 
 ---
 
 ## Discovery Log
+
+### 2026-08-15 — PHASE-002 (both gates found the same unfalsifiable assertion)
+
+- **Finding:** The test-review gate (should-cover #2) and the code review (veto V1) landed
+  independently on the same test: NF0504's message assertion stacked the *unphased* attribute
+  first, so the surviving phase was `Immediate` — which is simultaneously the hardcoded
+  default constant, the value the malformed-argument fallback returns, and what a message
+  format with the placeholder deleted would print. Green against three distinct wrong
+  implementations. Four other bullets *were* red-proofed; this was the one claim neither
+  pinned nor declared unpinnable.
+- **Decision:** Amend — added the phased-first case (which also pins source-order-wins,
+  previously unpinned) and red-proofed it by hardcoding the phase into the message format.
+  Three further should-cover gaps closed the same way: the relay leg had **no**
+  `IsServerRuntime` assertion anywhere in the unit suite, NF0504's location was unasserted
+  while the bullet claimed it, and the cache fixture's phase argument could silently stop
+  binding and degrade the fixture with every test still green.
+- **Follow-up:** [reviews/002-test-review.md](./reviews/002-test-review.md),
+  [reviews/002-code-review.md](./reviews/002-code-review.md),
+  [reviews/002-redproof.log](./reviews/002-redproof.log) (second round). Fourth instance of
+  the "can't go red" shape in this arc — and the first where red-proofing four discriminators
+  did *not* by itself prevent a fifth from slipping through, because the unproofed one was
+  not on the list.
+
+### 2026-08-15 — PHASE-002 (generator emission hygiene — new plan 008)
+
+- **Finding:** Both gates surfaced defects adjacent to this plan but outside it. The sharpest:
+  the **event type** token in the same emitted registration statement is *not* `global::`-
+  qualified — the identical hazard this plan spent a Constraint, a veto, and a negative pin on,
+  three tokens to the left. Also: attributes split across partial declarations should collide
+  on hint name (`ForAttributeWithMetadataName` fires per syntax node, the transform reads
+  `symbol.GetAttributes()`) — inferred, not measured; `DiagnosticTestHelper.RunGenerator`
+  returns every generator diagnostic **twice**, which no current test trips but which silently
+  breaks any count assertion; `RunGeneratorTracked` never checks the input compilation for CS
+  errors; and `NF04xx…Tests.cs` contains `class NF05xx…Tests`.
+- **Decision:** Re-split — new Index row 008 rather than widening PHASE-007, which both
+  reviewers noted already carries three unrelated items. Index changes: 008 added as Draft.
+- **Follow-up:** Note the ratchet on the `global::` item — five new assertions in this plan
+  hardcode the unqualified event-type form and will need editing when 008 lands.
+
+### 2026-08-15 — PHASE-002 (AfterFlush became consumer-reachable ahead of its drain point)
+
+- **Finding:** As of this plan `[FactoryEventHandler<T>(DispatchPhase.AfterFlush)]` is
+  expressible by consumers for the first time, and the scheduler's sweep already drains it at
+  the AfterCommit entry point — fail-open, but *without* the logged warning PHASE-004's
+  AC-5 promises. The feature is live and half-documented in the window between the two plans.
+- **Decision:** Accept the window; PHASE-002 does not own the warning. But PHASE-004's
+  acceptance must cover an **attribute-declared** AfterFlush handler, not only a
+  hand-registered one — otherwise the consumer-facing path stays untested.
+- **Follow-up:** recorded in PHASE-004's inherited section.
 
 ### 2026-08-15 — PHASE-002 (plan review: the duplicate-attribute severity, settled)
 

--- a/docs/todos/PHASE-phased-event-dispatch/todo.md
+++ b/docs/todos/PHASE-phased-event-dispatch/todo.md
@@ -82,6 +82,66 @@ exposes drain points.
 
 ## Discovery Log
 
+### 2026-08-15 — PHASE-002 (plan review: the duplicate-attribute severity, settled)
+
+- **Finding:** The draft took the deferred duplicate-same-event decision toward an **Error**
+  diagnostic, reasoning from "NF0501/NF0502 are errors". The review found the project's own
+  documented precedent pointing the other way: NF0503 chose Warning *explicitly* to keep the
+  build green for the identical shape (a declaration that compiles and is silently inert),
+  and the real dividing line in this generator is what gets emitted — NF0501/NF0502 add no
+  entry and the class emits no file at all, whereas a duplicate attribute still produces a
+  working registration.
+- **Decision:** Amend — **Warning**, paired with skipping the duplicate's entry at emission so
+  the generated output matches the diagnostic's message. Last-wins was the other option the
+  PHASE-001 entry queued by name; rejected because it needs the registry's dedupe key widened
+  (runtime work, not this plan's) and makes the winner depend on assembly-scan order. Warning
+  also keeps source that compiles at v1.7.0 compiling, so the arc stays a minor release.
+- **Follow-up:** [reviews/002-plan-review.md](./reviews/002-plan-review.md). Closes the
+  2026-08-14 PHASE-001 deferral below.
+
+### 2026-08-15 — PHASE-002 (a third "can't go red" bullet, caught before implementation)
+
+- **Finding:** Two of the draft's acceptance bullets could not fail for what they claimed.
+  The incremental-cache bullet asserts equality of transform outputs across runs, which any
+  deterministic scalar satisfies — a phase field hardcoded to `Immediate` passes it, and
+  because `ReplaceSyntaxTree` reuses the reference manager, even a `TypedConstant` field
+  (the actual cache hazard) would likely stay green. The emission bullet would have been
+  satisfied by a `Contains("DispatchPhase.AfterCommit")` that cannot distinguish the
+  `global::`-qualified form from the bare one — the latent bug `RelayHandlerRenderer.cs:38-40`
+  documents as having shipped for four releases.
+- **Decision:** Amend before the first edit — the cache bullet now claims only determinism
+  plus future collection-shaped-field coverage; the representation rule became a Constraint
+  enforced by code review rather than a claimed test; the qualification became a Constraint
+  with the acceptance bullet worded to require a negative pin on the bare form. A second
+  non-discriminating test was considered as a replacement and declined.
+- **Follow-up:** This is the "verify, don't inherit" failure mode recurring in a plan written
+  with that lesson loaded — the third instance in this arc. The pre-flight had *spotted* the
+  qualification and recorded it as an observation with nothing enforcing it, which is how it
+  would have been lost.
+
+### 2026-08-15 — PHASE-002 (docs this plan invalidates — handed to PHASE-005)
+
+- **Finding:** PHASE-002 is the plan that makes the attribute's phase real, so on the day it
+  lands, published prose describing all handlers as in-scope/in-transaction/before-`Raise`-
+  returns becomes conditionally false, and three diagnostics tables go stale. Concrete
+  anchors: `docs/attributes-reference.md:218` and `:202`,
+  `skills/RemoteFactory/references/factory-events.md:115` and `:541-543`,
+  `docs/factory-events.md:370-372`. PHASE-005's stub named the phase contract but not the
+  diagnostics tables.
+- **Decision:** Defer to PHASE-005 with the anchors recorded in its Scope, rather than
+  widening PHASE-002.
+- **Follow-up:** PHASE-005.
+
+### 2026-08-15 — PHASE-002 (undefined enum values are expressible and will not drain)
+
+- **Finding:** `[FactoryEventHandler<T>((DispatchPhase)99)]` compiles. Faithful pass-through
+  renders the cast, and the handler then never runs — the scheduler's drain sweeps only
+  defined phases, so the registration is a silent no-op.
+- **Decision:** Not diagnosed. Undefined enum values are a C# hazard generally, and policing
+  them is out of proportion to this plan. Recorded so the choice is visible rather than
+  accidental.
+- **Follow-up:** none. Revisit only if a consumer hits it.
+
 ### 2026-08-14 — PHASE-003 (code review: interface leg aligned on the registrar-holder shape)
 - **Finding:** Code review V1: introducing the wrapper/core split on the interface leg
   moved its bodies into private `Local*Core` methods while the assembly attribute still
@@ -213,6 +273,8 @@ exposes drain points.
 - **Decision:** Defer
 - **Follow-up:** PHASE-002 (likely a generator diagnostic for duplicate same-event
   attributes; decide there whether to diagnose or define last-wins semantics).
+  **Closed** 2026-08-15 — diagnose at Warning, skip the duplicate entry; see the PHASE-002
+  plan-review entry at the top of this log.
 
 ---
 

--- a/docs/todos/PHASE-phased-event-dispatch/todo.md
+++ b/docs/todos/PHASE-phased-event-dispatch/todo.md
@@ -77,7 +77,7 @@ exposes drain points.
 | 005 | [005-design-docs-skill](./plans/005-design-docs-skill.md) | Design projects, published docs, skill reference | Draft |
 | 006 | [006-coalescing](./plans/006-coalescing.md) | Opt-in same-event coalescing (v2, queued per user) | Draft |
 | 007 | *(not yet drafted)* | Tech debt: registry test-isolation hook (`Clear()` is internal and uncalled; every test invents unique event types); 9002/9004/9006 positive emission pins; `ClientServerContainers` tuple-order divergence + `ScopesWithLogging` duplication | Draft |
-| 008 | *(not yet drafted)* | Generator emission hygiene: `global::`-qualify the remaining emitted type tokens (event type in relay registration, and audit the other legs); probe the partial-declaration attribute-split hint-name collision; `DiagnosticTestHelper` returns every generator diagnostic twice and `RunGeneratorTracked` never checks the input compilation for CS errors; `NF04xx…Tests.cs` holds `class NF05xx…Tests` | Draft |
+| 008 | *(not yet drafted)* | Generator emission hygiene: `global::`-qualify the remaining emitted type tokens (event type in relay registration, and audit the other legs); probe the partial-declaration attribute-split hint-name collision; `RunGeneratorTracked` never checks the input compilation for CS errors; `NF04xx…Tests.cs` holds `class NF05xx…Tests`. *(The `DiagnosticTestHelper` double-count was pulled forward and fixed in PHASE-002.)* | Draft |
 
 ---
 
@@ -104,6 +104,25 @@ exposes drain points.
   the "can't go red" shape in this arc — and the first where red-proofing four discriminators
   did *not* by itself prevent a fifth from slipping through, because the unproofed one was
   not on the list.
+
+### 2026-08-15 — PHASE-002 (a red-proof that disproved its own premise)
+
+- **Finding:** Fixing `DiagnosticTestHelper`'s double-count, I wrote a comment warning that
+  `Distinct()` would be a destructive "obvious fix" — it would collapse genuinely repeated
+  diagnostics (NF0502 fires once per attribute, same location, identical message) because
+  `Diagnostic` has value equality. Red-proofing that claim showed it is **false**: comparison
+  behaves by identity, the doubling came from concatenating two collections holding the *same
+  instances*, and genuine repeats are distinct instances that survive. `Distinct()` would have
+  worked.
+- **Decision:** Keep the chosen fix — return the driver's out-param, no concatenation — but on
+  the corrected, narrower ground: `Distinct()`'s correctness depends on the two collections
+  sharing object identity, a Roslyn implementation detail nothing here controls. Rewrote the
+  helper comment and the test remarks, which had stated the disproved claim as fact.
+- **Follow-up:** Recorded in [reviews/002-redproof.log](./reviews/002-redproof.log) (RP-8)
+  rather than deleted. A confident-and-wrong warning comment in a shared test helper outlives
+  whoever wrote it; this one lasted three minutes because it was tested. Worth remembering that
+  red-proofing pays out twice — it confirms the tests that go red, and it kills the reasoning
+  that turns out to be decoration.
 
 ### 2026-08-15 — PHASE-002 (generator emission hygiene — new plan 008)
 

--- a/src/Design/CLAUDE-DESIGN.md
+++ b/src/Design/CLAUDE-DESIGN.md
@@ -260,7 +260,8 @@ services.AddNeatooRemoteFactory(NeatooFactory.Remote, typeof(Order).Assembly);
 - `FactoryEventTypeRegistry` (internal, runtime) lazily scans `AppDomain.CurrentDomain.GetAssemblies()` on first use; rescans on miss to pick up dynamically-loaded assemblies. Logs EventId 3012 (Warning) on `FullName` collisions.
 - In Remote mode, if the consumer registers nothing, `NoOpFactoryEventRelay` is registered via `TryAddSingleton`. It logs EventId 3011 (Warning) once per process on the first non-empty batch it drops — a signal the consumer forgot to register a custom relay.
 - Logical mode registers neither the collector nor the relay (no cross-boundary communication needed). Server mode does not register `IFactoryEventRelay`.
-- NF0501 if no matching server handler method; NF0502 if multiple methods match; NF0503 (Warning) if an instance method is declared inside a `[FactoryEventHandler<T>]` class.
+- NF0501 if no matching server handler method; NF0502 if multiple methods match; NF0503 (Warning) if an instance method is declared inside a `[FactoryEventHandler<T>]` class; NF0504 (Warning) if one class declares the same event type more than once.
+- The attribute's `DispatchPhase` argument reaches registration: `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` registers at that phase, no argument registers at `Immediate`. The phase is per-attribute, so one class can hold several event types at different phases.
 
 ---
 
@@ -1005,6 +1006,7 @@ These are known limitations or open questions. They are documented here to preve
 | NF0501 | Error | `[FactoryEventHandler<T>]` class has no matching method | Declare exactly one method returning `Task` whose first non-`[Service]`/non-`CancellationToken` parameter is of type `T` |
 | NF0502 | Error | `[FactoryEventHandler<T>]` class has multiple matching methods | Remove the extras or split into separate handler classes |
 | NF0503 | Warning | `[FactoryEventHandler<T>]` class has an **instance**-method handler (former client-relay pattern) | Make the method `static` (server-side handler) **or** implement `IFactoryEventRelay` on the class and register it in DI (client-side reception). Instance methods are silently skipped at runtime. |
+| NF0504 | Warning | One class declares `[FactoryEventHandler<T>]` for the **same** event type more than once | Remove the duplicate. Stacking is for several event *types*; a repeat resolves to the same handler method, so only the first declaration registers — including its phase. The message names the surviving phase. |
 
 ### Runtime Log Events
 

--- a/src/Generator/DiagnosticDescriptors.cs
+++ b/src/Generator/DiagnosticDescriptors.cs
@@ -247,4 +247,30 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Client-side instance-method [FactoryEventHandler<T>] handlers were the former relay pattern and are no longer wired up. Convert the method to static for server-side dispatch, or implement IFactoryEventRelay on the class for client-side event reception.");
+
+    /// <summary>
+    /// NF0504: The same event type is declared more than once on one handler class.
+    /// </summary>
+    /// <remarks>
+    /// Warning, not Error, and deliberately so — the severity split in this generator tracks
+    /// what gets emitted rather than how wrong the source is. NF0501/NF0502 add no entry and
+    /// the class emits no file at all, so those declarations are dead. A duplicate event type
+    /// still produces a working registration; only the second declaration is inert. That is
+    /// NF0503's shape, whose Warning severity was chosen to keep the build green.
+    /// <para>
+    /// The duplicate can never carry its own handler: the transform matches handler methods by
+    /// shape (first non-[Service], non-CancellationToken parameter of the event type), not per
+    /// attribute, so both declarations resolve to the same method — and two methods matching
+    /// one event is NF0502. Stacking is for several event <i>types</i>, which is what the
+    /// published attribute reference documents.
+    /// </para>
+    /// </remarks>
+    public static readonly DiagnosticDescriptor RelayHandlerDuplicateEventType = new(
+        id: "NF0504",
+        title: "Duplicate [FactoryEventHandler<T>] for the same event type",
+        messageFormat: "Class '{0}' declares [FactoryEventHandler<{1}>] more than once. The duplicate is ignored and the handler is registered at DispatchPhase.{2}. Stack [FactoryEventHandler<T>] for different event types, not for different phases on one event.",
+        category: CategoryUsage,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A handler class can stack [FactoryEventHandler<T>] attributes for several different event types, but declaring the same event type more than once registers the same handler method twice. Only the first declaration takes effect; the rest are ignored, including any phase they specify.");
 }

--- a/src/Generator/FactoryGenerator.RelayHandler.cs
+++ b/src/Generator/FactoryGenerator.RelayHandler.cs
@@ -13,12 +13,6 @@ namespace Neatoo;
 public partial class Factory
 {
     /// <summary>
-    /// Transforms a class decorated with [FactoryEventHandler&lt;T&gt;] into a RelayHandlerModel.
-    /// Extracts event types from the generic attribute and finds matching handler methods.
-    /// A matching method: non-private, returns Task, first non-[Service]/non-CT parameter is T.
-    /// Static methods → server-side handler. Instance methods → client-side relay handler.
-    /// </summary>
-    /// <summary>
     /// Reads the <c>DispatchPhase</c> argument off a <c>[FactoryEventHandler&lt;T&gt;]</c>
     /// attribute, as the member's name plus its numeric value. No argument means the
     /// attribute's parameterless constructor, which is <c>Immediate</c>.
@@ -44,22 +38,31 @@ public partial class Factory
         if (attr.ConstructorArguments.Length == 0)
             return (ImmediateName, ImmediateValue);
 
+        // Pattern match rather than Convert.ToInt32, matching the idiom already used for
+        // attribute constructor arguments in FactoryGenerator.cs. Convert throws on a
+        // non-IConvertible, a non-numeric string, or an out-of-range value, and a throw inside
+        // a transform surfaces as CS8785 "generator failed to generate source" — taking every
+        // other generated file in the compilation down with it, not just this one. No shape
+        // that compiles is known to reach those, but the crash class is not worth carrying for
+        // a construct that costs nothing to write safely.
         var arg = attr.ConstructorArguments[0];
-        if (arg.Kind == TypedConstantKind.Error || arg.Value == null)
+        if (arg.Kind == TypedConstantKind.Error || arg.Value is not int value)
             return (ImmediateName, ImmediateValue);
-
-        var value = Convert.ToInt32(arg.Value, CultureInfo.InvariantCulture);
 
         var member = (arg.Type as INamedTypeSymbol)?
             .GetMembers()
             .OfType<IFieldSymbol>()
-            .FirstOrDefault(f => f.HasConstantValue
-                && f.ConstantValue != null
-                && Convert.ToInt32(f.ConstantValue, CultureInfo.InvariantCulture) == value);
+            .FirstOrDefault(f => f.HasConstantValue && f.ConstantValue is int fieldValue && fieldValue == value);
 
         return (member?.Name ?? "", value);
     }
 
+    /// <summary>
+    /// Transforms a class decorated with [FactoryEventHandler&lt;T&gt;] into a RelayHandlerModel.
+    /// Extracts event types from the generic attribute and finds matching handler methods.
+    /// A matching method: non-private, returns Task, first non-[Service]/non-CT parameter is T.
+    /// Static methods → server-side handler. Instance methods → client-side relay handler.
+    /// </summary>
     private static RelayHandlerModel? TransformRelayHandler(ClassDeclarationSyntax classDecl, SemanticModel semanticModel)
     {
         var symbol = semanticModel.GetDeclaredSymbol(classDecl);
@@ -84,6 +87,12 @@ public partial class Factory
         // NF0501/NF0502 nothing is registered, so there is no surviving phase to name and no
         // duplicate to report. The second declaration then repeats the scan and repeats that
         // diagnostic, exactly as it did before NF0504 existed.
+        //
+        // One count DOES change, in a shape no test covers: a class with a duplicate attribute
+        // AND a matching instance method now emits NF0503 once instead of twice, because the
+        // duplicate short-circuits before the instance-method scan. Reporting one migration
+        // warning per class instead of one per redundant attribute is the better outcome, so
+        // this is recorded rather than worked around.
         var registeredPhaseByEventType = new Dictionary<string, string>();
 
         // Check partial
@@ -288,7 +297,7 @@ public partial class Factory
                 phaseValue: phaseValue));
 
             registeredPhaseByEventType[eventTypeName] =
-                phaseName.Length > 0 ? phaseName : phaseValue.ToString();
+                phaseName.Length > 0 ? phaseName : phaseValue.ToString(CultureInfo.InvariantCulture);
         }
 
         if (entries.Count == 0 && diagnostics.Count == 0)

--- a/src/Generator/FactoryGenerator.RelayHandler.cs
+++ b/src/Generator/FactoryGenerator.RelayHandler.cs
@@ -5,6 +5,7 @@ using Neatoo.RemoteFactory.FactoryGenerator;
 using Neatoo.RemoteFactory.Generator;
 using Neatoo.RemoteFactory.Generator.Model;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Neatoo;
@@ -17,6 +18,48 @@ public partial class Factory
     /// A matching method: non-private, returns Task, first non-[Service]/non-CT parameter is T.
     /// Static methods → server-side handler. Instance methods → client-side relay handler.
     /// </summary>
+    /// <summary>
+    /// Reads the <c>DispatchPhase</c> argument off a <c>[FactoryEventHandler&lt;T&gt;]</c>
+    /// attribute, as the member's name plus its numeric value. No argument means the
+    /// attribute's parameterless constructor, which is <c>Immediate</c>.
+    /// </summary>
+    /// <remarks>
+    /// Two deliberate choices here. The member name is looked up on the enum symbol instead of
+    /// being mapped from a hardcoded table, so a phase added to the runtime enum flows through
+    /// with no generator change. And only primitives escape this method — the
+    /// <c>TypedConstant</c> and the <c>IFieldSymbol</c> stay local, because either one stored
+    /// on the transform output would root a <c>Compilation</c> in the incremental cache.
+    /// <para>
+    /// An empty name means the declared value matches no member — an explicit cast to an
+    /// undefined value. Rendered faithfully as a cast rather than diagnosed or silently
+    /// coerced; such a handler registers and never drains, since the scheduler sweeps only
+    /// defined phases.
+    /// </para>
+    /// </remarks>
+    private static (string Name, int Value) ReadDispatchPhase(AttributeData attr)
+    {
+        const string ImmediateName = "Immediate";
+        const int ImmediateValue = 0;
+
+        if (attr.ConstructorArguments.Length == 0)
+            return (ImmediateName, ImmediateValue);
+
+        var arg = attr.ConstructorArguments[0];
+        if (arg.Kind == TypedConstantKind.Error || arg.Value == null)
+            return (ImmediateName, ImmediateValue);
+
+        var value = Convert.ToInt32(arg.Value, CultureInfo.InvariantCulture);
+
+        var member = (arg.Type as INamedTypeSymbol)?
+            .GetMembers()
+            .OfType<IFieldSymbol>()
+            .FirstOrDefault(f => f.HasConstantValue
+                && f.ConstantValue != null
+                && Convert.ToInt32(f.ConstantValue, CultureInfo.InvariantCulture) == value);
+
+        return (member?.Name ?? "", value);
+    }
+
     private static RelayHandlerModel? TransformRelayHandler(ClassDeclarationSyntax classDecl, SemanticModel semanticModel)
     {
         var symbol = semanticModel.GetDeclaredSymbol(classDecl);
@@ -28,6 +71,20 @@ public partial class Factory
 
         var classLocation = classDecl.Identifier.GetLocation();
         var classLineSpan = classLocation.GetLineSpan();
+
+        // Event types that already produced an entry, mapped to the phase that entry
+        // registered at. Stacking [FactoryEventHandler<T>] is for several event TYPES; a
+        // repeat of the same type resolves to the same handler method (the scan below is a
+        // pure function of the event type, not of which attribute is being processed), so a
+        // duplicate could only re-register what the first declaration already registered —
+        // and FactoryEventHandlerRegistry keeps the first. NF0504 reports it and the entry is
+        // skipped, so the emitted code matches what the diagnostic says.
+        //
+        // Populated only on SUCCESS, deliberately: when the first declaration failed with
+        // NF0501/NF0502 nothing is registered, so there is no surviving phase to name and no
+        // duplicate to report. The second declaration then repeats the scan and repeats that
+        // diagnostic, exactly as it did before NF0504 existed.
+        var registeredPhaseByEventType = new Dictionary<string, string>();
 
         // Check partial
         if (!classDecl.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
@@ -61,6 +118,23 @@ public partial class Factory
             var eventTypeName = eventType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             if (eventTypeName.StartsWith("global::"))
                 eventTypeName = eventTypeName.Substring("global::".Length);
+
+            if (registeredPhaseByEventType.TryGetValue(eventTypeName, out var survivingPhase))
+            {
+                diagnostics.Add(new DiagnosticInfo(
+                    "NF0504",
+                    classLineSpan.Path ?? "",
+                    classLineSpan.StartLinePosition.Line,
+                    classLineSpan.StartLinePosition.Character,
+                    classLineSpan.EndLinePosition.Line,
+                    classLineSpan.EndLinePosition.Character,
+                    classLocation.SourceSpan.Start,
+                    classLocation.SourceSpan.Length,
+                    symbol.Name,
+                    eventTypeName,
+                    survivingPhase));
+                continue;
+            }
 
             // Find matching STATIC methods. Instance-method handlers are the former
             // client-side relay pattern (now replaced by IFactoryEventRelay) — they are
@@ -200,6 +274,8 @@ public partial class Factory
             bool isAsync = method.IsAsync ||
                 (method.ReturnType.ToDisplayString() == "System.Threading.Tasks.Task" && method.IsAsync);
 
+            var (phaseName, phaseValue) = ReadDispatchPhase(attr);
+
             entries.Add(new EventHandlerEntry(
                 eventTypeName: eventTypeName,
                 methodName: method.Name,
@@ -207,7 +283,12 @@ public partial class Factory
                 isAsync: method.IsAsync,
                 parameters: parameters,
                 serviceParameters: serviceParameters,
-                allParameters: allParameters));
+                allParameters: allParameters,
+                phaseName: phaseName,
+                phaseValue: phaseValue));
+
+            registeredPhaseByEventType[eventTypeName] =
+                phaseName.Length > 0 ? phaseName : phaseValue.ToString();
         }
 
         if (entries.Count == 0 && diagnostics.Count == 0)

--- a/src/Generator/FactoryGenerator.cs
+++ b/src/Generator/FactoryGenerator.cs
@@ -153,6 +153,7 @@ public partial class Factory : IIncrementalGenerator
 			"NF0501" => DiagnosticDescriptors.RelayHandlerMethodNotFound,
 			"NF0502" => DiagnosticDescriptors.RelayHandlerMethodAmbiguous,
 			"NF0503" => DiagnosticDescriptors.RelayHandlerInstanceMethodIgnored,
+			"NF0504" => DiagnosticDescriptors.RelayHandlerDuplicateEventType,
 			_ => throw new ArgumentException($"Unknown diagnostic ID: {diagnosticId}")
 		};
 	}

--- a/src/Generator/Model/RelayHandlerModel.cs
+++ b/src/Generator/Model/RelayHandlerModel.cs
@@ -64,7 +64,9 @@ internal sealed record EventHandlerEntry
         bool isAsync,
         IReadOnlyList<ParameterModel> parameters,
         IReadOnlyList<ParameterModel> serviceParameters,
-        IReadOnlyList<ParameterModel> allParameters)
+        IReadOnlyList<ParameterModel> allParameters,
+        string phaseName,
+        int phaseValue)
     {
         EventTypeName = eventTypeName;
         MethodName = methodName;
@@ -73,10 +75,39 @@ internal sealed record EventHandlerEntry
         Parameters = new EquatableArray<ParameterModel>([.. parameters]);
         ServiceParameters = new EquatableArray<ParameterModel>([.. serviceParameters]);
         AllParameters = new EquatableArray<ParameterModel>([.. allParameters]);
+        PhaseName = phaseName;
+        PhaseValue = phaseValue;
     }
 
     public string EventTypeName { get; }
     public string MethodName { get; }
+
+    /// <summary>
+    /// Name of the <c>DispatchPhase</c> member the attribute declared — <c>"Immediate"</c> when
+    /// the consumer wrote no argument. Empty when the declared value matches no member of the
+    /// runtime enum, i.e. an explicit cast to an undefined value; the renderer then falls back
+    /// to <see cref="PhaseValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// The phase is carried as primitives — never a <c>TypedConstant</c>, never an
+    /// <c>ISymbol</c>. Both of those drag a <c>Compilation</c> into the incremental cache
+    /// through this record's equality, and the caching test cannot see it: it compares
+    /// transform outputs across two runs that share a reference manager, so symbol-bearing
+    /// fields compare equal and the leak stays green. Enforced by review, not by a test.
+    /// <para>
+    /// <c>DispatchPhase</c> itself is deliberately unavailable here — see the type-duplication
+    /// warning on <c>FactoryEventHandlerAttribute&lt;T&gt;</c>. The member name is looked up on
+    /// the enum symbol rather than hardcoded, so a phase added to the runtime enum needs no
+    /// generator change.
+    /// </para>
+    /// </remarks>
+    public string PhaseName { get; }
+
+    /// <summary>
+    /// Numeric value of the declared phase. Only load-bearing when <see cref="PhaseName"/> is
+    /// empty; otherwise the name is what gets rendered.
+    /// </summary>
+    public int PhaseValue { get; }
 
     /// <summary>
     /// Always <c>true</c> — the generator only emits registrations for static handlers now.

--- a/src/Generator/Renderer/RelayHandlerRenderer.cs
+++ b/src/Generator/Renderer/RelayHandlerRenderer.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Neatoo.RemoteFactory.Generator.Model;
@@ -154,9 +155,13 @@ internal static class RelayHandlerRenderer
 
         // An empty name means the consumer cast an undefined value onto the enum; render it
         // faithfully rather than coercing it to a phase they did not ask for.
+        // InvariantCulture on the numeric fallback: interpolation would format with the
+        // build machine's CurrentCulture, and a negative value on a culture whose negative
+        // sign is not ASCII '-' (sv-SE resolves to U+2212 under ICU) emits a CS1056 into the
+        // consumer's build. `(DispatchPhase)(-1)` compiles, so the path is reachable.
         var phase = handler.PhaseName.Length > 0
             ? $"{DispatchPhaseType}.{handler.PhaseName}"
-            : $"({DispatchPhaseType}){handler.PhaseValue}";
+            : $"({DispatchPhaseType}){handler.PhaseValue.ToString(CultureInfo.InvariantCulture)}";
 
         // Emit arguments in declaration order so a handler like
         // `(TestEvent evt, CancellationToken ct, [Service] IFoo svc)` binds correctly.

--- a/src/Generator/Renderer/RelayHandlerRenderer.cs
+++ b/src/Generator/Renderer/RelayHandlerRenderer.cs
@@ -117,15 +117,46 @@ internal static class RelayHandlerRenderer
     }
 
     /// <summary>
-    /// Server-side: register into FactoryEventHandlerRegistry. Handlers run in the
-    /// caller's DI scope (shared DbContext/transaction), sequentially, awaited.
-    /// [Service] parameters resolve from the caller's sp. CancellationToken flows
-    /// through from IFactoryEvents.Raise. Invocation arguments are emitted in the
-    /// order the user declared them on the handler method.
+    /// Fully-qualified name of the runtime dispatch-phase enum, as literal text.
     /// </summary>
+    /// <remarks>
+    /// Text, not a type reference: the enum cannot be referenced from this netstandard2.0
+    /// project without duplicating a public runtime type (see the warning on
+    /// <c>FactoryEventHandlerAttribute&lt;T&gt;</c>).
+    /// <para>
+    /// <c>global::</c>-qualified for the same reason as the assembly attribute above, and it
+    /// is load-bearing for the same reason: a consumer namespace shadowing the first segment
+    /// of this one would otherwise bind the argument to the wrong type. The generated file's
+    /// <c>using Neatoo.RemoteFactory;</c> is not enough — that bug shipped for four releases
+    /// on the attribute before v1.7.0, and this is a new type-bearing token in the same file.
+    /// </para>
+    /// </remarks>
+    private const string DispatchPhaseType = "global::Neatoo.RemoteFactory.DispatchPhase";
+
+    /// <summary>
+    /// Server-side: register into FactoryEventHandlerRegistry at the phase the attribute
+    /// declared. Handlers run in the caller's DI scope; <c>Immediate</c> handlers dispatch at
+    /// raise time (shared DbContext/transaction), later phases are queued and drained at their
+    /// drain point. [Service] parameters resolve from the caller's sp. CancellationToken flows
+    /// through from IFactoryEvents.Raise. Invocation arguments are emitted in the order the
+    /// user declared them on the handler method.
+    /// </summary>
+    /// <remarks>
+    /// The phase-taking overload is emitted for every handler, including unphased ones, so
+    /// there is one shape to read and one path to test — the defaulted case pins
+    /// <c>Immediate</c> positively rather than pinning an absence. This leaves the two-argument
+    /// <c>RegisterHandler</c> overload with no generated call sites; it stays because it is
+    /// public API.
+    /// </remarks>
     private static void RenderServerSideHandler(StringBuilder sb, EventHandlerEntry handler, string className)
     {
         var eventTypeName = handler.EventTypeName;
+
+        // An empty name means the consumer cast an undefined value onto the enum; render it
+        // faithfully rather than coercing it to a phase they did not ask for.
+        var phase = handler.PhaseName.Length > 0
+            ? $"{DispatchPhaseType}.{handler.PhaseName}"
+            : $"({DispatchPhaseType}){handler.PhaseValue}";
 
         // Emit arguments in declaration order so a handler like
         // `(TestEvent evt, CancellationToken ct, [Service] IFoo svc)` binds correctly.
@@ -139,7 +170,7 @@ internal static class RelayHandlerRenderer
 
         sb.AppendLine("            if (NeatooRuntime.IsServerRuntime)");
         sb.AppendLine("            {");
-        sb.AppendLine($"                FactoryEventHandlerRegistry.RegisterHandler<{eventTypeName}>(typeof({className}), async (sp, eventObj, options, ct) =>");
+        sb.AppendLine($"                FactoryEventHandlerRegistry.RegisterHandler<{eventTypeName}>(typeof({className}), {phase}, async (sp, eventObj, options, ct) =>");
         sb.AppendLine("                {");
         sb.AppendLine($"                    var {handler.Parameters.First(p => !p.IsCancellationToken).Name} = ({eventTypeName})eventObj;");
         if (!string.IsNullOrEmpty(serviceAssignments))

--- a/src/Tests/RemoteFactory.IntegrationTests/Events/Phases/FactoryEventPhaseAttributeTests.cs
+++ b/src/Tests/RemoteFactory.IntegrationTests/Events/Phases/FactoryEventPhaseAttributeTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.DependencyInjection;
+using RemoteFactory.IntegrationTests.TestContainers;
+using RemoteFactory.IntegrationTests.TestTargets.Events;
+
+namespace RemoteFactory.IntegrationTests.Events.Phases;
+
+/// <summary>
+/// End-to-end coverage for PHASE-002: a phase declared on
+/// <c>[FactoryEventHandler&lt;T&gt;]</c> and registered by generated code actually
+/// governs when the handler runs.
+/// </summary>
+/// <remarks>
+/// The falsifiability condition these tests rest on: nothing here — and nothing in
+/// <c>FactoryEventPhaseAttributeTargets</c> — calls
+/// <c>FactoryEventHandlerRegistry.RegisterHandler</c>. Registration happens because
+/// the generator emits a registrar, the assembly attribute names it, and
+/// <c>AddNeatooRemoteFactory</c> invokes it reflectively at container build. Sibling
+/// tests in <c>FactoryEventPhaseEntryTests</c> deliberately hand-register instead, so
+/// they would stay green against a generator that ignored the phase entirely; these
+/// would not.
+/// <para>
+/// No constructor call to <c>PhaseHandlerRegistrations.EnsureRegistered()</c>, unlike
+/// the PHASE-003 tests — needing one would mean the generated registration was not
+/// doing the work.
+/// </para>
+/// </remarks>
+public class FactoryEventPhaseAttributeTests
+{
+    private static List<string> RecordedFor(IServiceScope scope, Guid id)
+    {
+        return scope.GetRequiredService<IEventTestService>()
+            .GetRecordedEvents()
+            .Where(e => e.EntityId == id)
+            .Select(e => e.EventName)
+            .ToList();
+    }
+
+    /// <summary>
+    /// HTTP-dispatched <c>[Remote]</c> entry call: the attribute-declared AfterCommit
+    /// handler runs after the factory method body returns, the unphased one inline.
+    /// </summary>
+    [Fact]
+    public async Task RemoteCreate_AttributeDeclaredPhases_GovernWhenHandlersRun()
+    {
+        var (server, client, _) = ClientServerContainers.Scopes();
+        var factory = client.GetRequiredService<IPhaseAttributeTargetFactory>();
+        var id = Guid.NewGuid();
+
+        await factory.Create(id);
+
+        // Raise order was projection-then-atomic; the drain inverts it. A generator that
+        // dropped the phase argument would register both at Immediate and produce
+        // ["attr-after-commit", "attr-immediate", "attr-method-done"].
+        Assert.Equal(["attr-immediate", "attr-method-done", "attr-after-commit"], RecordedFor(server, id));
+    }
+
+    /// <summary>
+    /// Direct Logical invocation through the generated wrapper seam reaches the same
+    /// drain point as the remote choke point.
+    /// </summary>
+    [Fact]
+    public async Task LogicalCreate_AttributeDeclaredPhases_GovernWhenHandlersRun()
+    {
+        var (_, _, local) = ClientServerContainers.Scopes();
+        var factory = local.GetRequiredService<IPhaseAttributeTargetFactory>();
+        var id = Guid.NewGuid();
+
+        await factory.Create(id);
+
+        Assert.Equal(["attr-immediate", "attr-method-done", "attr-after-commit"], RecordedFor(local, id));
+    }
+}

--- a/src/Tests/RemoteFactory.IntegrationTests/TestTargets/Events/FactoryEventPhaseAttributeTargets.cs
+++ b/src/Tests/RemoteFactory.IntegrationTests/TestTargets/Events/FactoryEventPhaseAttributeTargets.cs
@@ -1,0 +1,102 @@
+using Neatoo.RemoteFactory;
+
+namespace RemoteFactory.IntegrationTests.TestTargets.Events;
+
+// =============================================================================
+// PHASE-002 ATTRIBUTE-DECLARED PHASE TARGETS
+// =============================================================================
+//
+// The end-to-end closure of the phase feature: handlers here declare their phase
+// through [FactoryEventHandler<T>(DispatchPhase.X)] and register through the
+// GENERATED registrar. Nothing in this file or its tests calls
+// FactoryEventHandlerRegistry.RegisterHandler.
+//
+// That distinction is the whole point. PHASE-003's targets register through the
+// registry's 3-arg overload by hand (see PhaseHandlerRegistrations), which proved
+// the runtime drains a phased handler but said nothing about whether a consumer
+// writing the attribute gets one — and until PHASE-002 they did not: the generator
+// read the attribute's type argument and never its constructor arguments, so every
+// registration landed at Immediate.
+//
+// Same one-event-type-per-scenario discipline as the PHASE-003 targets: the
+// registry is process-global with (eventType, handlerClass) first-registration-wins
+// dedupe and no test-isolation hook (PHASE-007), so a shared event type silently
+// drops registrations. These two types appear nowhere else.
+
+// -----------------------------------------------------------------------------
+// EVENTS
+// -----------------------------------------------------------------------------
+
+public record AttributePhasedProjectionEvent(Guid Id) : FactoryEventBase;
+public record AttributePhasedAtomicEvent(Guid Id) : FactoryEventBase;
+
+// -----------------------------------------------------------------------------
+// HANDLERS — phase declared on the attribute, registered by generated code
+// -----------------------------------------------------------------------------
+
+/// <summary>
+/// Read-only projection handler: declared <c>AfterCommit</c>, so it must run at the
+/// entry-call drain rather than inline at raise time.
+/// </summary>
+[FactoryEventHandler<AttributePhasedProjectionEvent>(DispatchPhase.AfterCommit)]
+public static partial class AttributePhasedProjectionHandler
+{
+    internal static Task Project(
+        AttributePhasedProjectionEvent projectionEvent,
+        [Service] IEventTestService testService)
+    {
+        testService.RecordEventFired("attr-after-commit", projectionEvent.Id);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Atomic handler with no phase argument: the pre-existing contract, dispatched
+/// inline at raise time.
+/// </summary>
+[FactoryEventHandler<AttributePhasedAtomicEvent>]
+public static partial class AttributePhasedAtomicHandler
+{
+    internal static Task Apply(
+        AttributePhasedAtomicEvent atomicEvent,
+        [Service] IEventTestService testService)
+    {
+        testService.RecordEventFired("attr-immediate", atomicEvent.Id);
+        return Task.CompletedTask;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// FACTORY TARGET
+// -----------------------------------------------------------------------------
+
+/// <summary>
+/// Raises both events, then records its own completion marker last.
+/// </summary>
+/// <remarks>
+/// The marker is the ordering discriminator, same as PHASE-003's targets: a handler
+/// recorded BEFORE "attr-method-done" ran inline at raise time; one recorded AFTER it
+/// provably ran at the entry drain. Raising the AfterCommit event FIRST and the
+/// Immediate event second means a generator that ignored the phase — registering both
+/// at Immediate — would produce the raise order, which is the reverse of what the test
+/// asserts. The sequence cannot pass by accident.
+/// </remarks>
+[Factory]
+public partial class PhaseAttributeTarget
+{
+    public Guid Id { get; set; }
+
+    [Create]
+    [Remote]
+    internal async Task Create(
+        Guid id,
+        [Service] IFactoryEvents events,
+        [Service] IEventTestService testService,
+        CancellationToken ct)
+    {
+        Id = id;
+        await events.Raise(new AttributePhasedProjectionEvent(id), RaiseOptions.None, ct);
+        await events.Raise(new AttributePhasedAtomicEvent(id), RaiseOptions.None, ct);
+        testService.RecordEventFired("attr-method-done", id);
+    }
+}

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using RemoteFactory.UnitTests.TestContainers;
+using System.Globalization;
 
 namespace RemoteFactory.UnitTests.FactoryGenerator;
 
@@ -744,6 +745,275 @@ namespace TestNamespace
 
         Assert.Contains("CS0111", errorIds);
         Assert.DoesNotContain("CS0101", errorIds);
+    }
+
+    #endregion
+
+    #region Relay Handler — Dispatch Phase (PHASE-002)
+
+    /// <summary>
+    /// Two event types on one class, one explicitly phased and one defaulted.
+    /// </summary>
+    /// <remarks>
+    /// The two attributes must name DIFFERENT events — same-event stacking is NF0504 and skips
+    /// the duplicate's entry, which would silently remove whichever registration a test here
+    /// was trying to assert. Distinct handler methods for the same reason: two methods matching
+    /// one event is NF0502 and emits nothing at all.
+    /// </remarks>
+    private const string PhasedRelayHandlerSource = @"
+using Neatoo.RemoteFactory;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestNamespace
+{
+    public record ProjectionEvent(int Id) : FactoryEventBase;
+    public record AtomicEvent(int Id) : FactoryEventBase;
+
+    [FactoryEventHandler<ProjectionEvent>(DispatchPhase.AfterCommit)]
+    [FactoryEventHandler<AtomicEvent>]
+    public static partial class MixedHandlers
+    {
+        internal static Task Project(ProjectionEvent evt) => Task.CompletedTask;
+
+        internal static Task Apply(AtomicEvent evt) => Task.CompletedTask;
+    }
+}
+";
+
+    private static string GeneratedSourceFor(string source, string hintFragment)
+    {
+        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        var generatedSource = runResult.GeneratedTrees
+            .FirstOrDefault(t => t.FilePath.Contains(hintFragment))
+            ?.GetText()
+            ?.ToString();
+
+        Assert.NotNull(generatedSource);
+        return generatedSource;
+    }
+
+    /// <summary>
+    /// A handler declaring no phase argument registers at <c>Immediate</c> — the pre-PHASE-002
+    /// contract, now stated positively in the emitted call rather than implied by an absence.
+    /// </summary>
+    /// <remarks>
+    /// The phase-taking overload is emitted for every handler, including defaulted ones, so this
+    /// asserts the argument is present and correct rather than asserting the two-argument form.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_UnphasedHandler_RegistersAtImmediate()
+    {
+        var generatedSource = GeneratedSourceFor(RelayHandlerSource, "MyHandlers");
+
+        Assert.Contains(
+            "FactoryEventHandlerRegistry.RegisterHandler<TestNamespace.MyEvent>(typeof(MyHandlers), global::Neatoo.RemoteFactory.DispatchPhase.Immediate, async (sp, eventObj, options, ct) =>",
+            generatedSource);
+    }
+
+    /// <summary>
+    /// An explicitly phased handler registers at the phase the attribute declared.
+    /// </summary>
+    /// <remarks>
+    /// Before PHASE-002 the generator read the attribute's type argument and never its
+    /// constructor arguments, so this assertion is the one that would have caught the phase
+    /// being silently dropped — every registration landed at <c>Immediate</c> no matter what
+    /// the consumer wrote.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_PhasedHandler_RegistersAtTheDeclaredPhase()
+    {
+        var generatedSource = GeneratedSourceFor(PhasedRelayHandlerSource, "MixedHandlers");
+
+        Assert.Contains(
+            "FactoryEventHandlerRegistry.RegisterHandler<TestNamespace.ProjectionEvent>(typeof(MixedHandlers), global::Neatoo.RemoteFactory.DispatchPhase.AfterCommit, async (sp, eventObj, options, ct) =>",
+            generatedSource);
+    }
+
+    /// <summary>
+    /// One class declaring several event types at different phases registers each at its own
+    /// phase — the phase is per-attribute, not per-class.
+    /// </summary>
+    [Fact]
+    public void RelayHandler_SeveralEventTypes_EachRegistersAtItsOwnPhase()
+    {
+        var generatedSource = GeneratedSourceFor(PhasedRelayHandlerSource, "MixedHandlers");
+
+        Assert.Contains(
+            "RegisterHandler<TestNamespace.ProjectionEvent>(typeof(MixedHandlers), global::Neatoo.RemoteFactory.DispatchPhase.AfterCommit,",
+            generatedSource);
+        Assert.Contains(
+            "RegisterHandler<TestNamespace.AtomicEvent>(typeof(MixedHandlers), global::Neatoo.RemoteFactory.DispatchPhase.Immediate,",
+            generatedSource);
+    }
+
+    /// <summary>
+    /// The emitted phase argument is <c>global::</c>-qualified.
+    /// </summary>
+    /// <remarks>
+    /// The positive assertions above would pass just as happily on a bare
+    /// <c>DispatchPhase.AfterCommit</c> bound by the generated file's <c>using</c>, so they
+    /// cannot pin this. The unqualified form is the latent bug documented at
+    /// <c>RelayHandlerRenderer.cs:38-40</c> — it shipped for four releases on the registrar
+    /// attribute, where a consumer namespace shadowing the first segment of ours bound the
+    /// argument to the wrong type. This plan emits a NEW type-bearing token into the same file,
+    /// so it needs the same negative pin the registrar attribute got.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_PhaseArgument_IsGlobalQualified()
+    {
+        var generatedSource = GeneratedSourceFor(PhasedRelayHandlerSource, "MixedHandlers");
+
+        // The argument position specifically: qualified emission always reads
+        // ", global::Neatoo.RemoteFactory.DispatchPhase.", never ", DispatchPhase.".
+        Assert.DoesNotContain(", DispatchPhase.", generatedSource);
+        Assert.Contains(", global::Neatoo.RemoteFactory.DispatchPhase.", generatedSource);
+    }
+
+    /// <summary>
+    /// A value cast onto the enum that matches no member renders as a cast rather than being
+    /// coerced to a phase the consumer did not ask for.
+    /// </summary>
+    /// <remarks>
+    /// Pins a decision, not an aspiration: such a handler registers and then never drains,
+    /// because the scheduler sweeps only defined phases. Diagnosing it was judged out of
+    /// proportion for this plan (todo Discovery Log, 2026-08-15). Silently coercing it to
+    /// <c>Immediate</c> would be worse — it would run handlers at a phase nobody declared.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_UndefinedPhaseValue_RendersAsACast()
+    {
+        var source = PhasedRelayHandlerSource.Replace(
+            "[FactoryEventHandler<ProjectionEvent>(DispatchPhase.AfterCommit)]",
+            "[FactoryEventHandler<ProjectionEvent>((DispatchPhase)99)]");
+
+        Assert.NotEqual(PhasedRelayHandlerSource, source);
+
+        var generatedSource = GeneratedSourceFor(source, "MixedHandlers");
+
+        Assert.Contains(
+            "typeof(MixedHandlers), (global::Neatoo.RemoteFactory.DispatchPhase)99, async (sp, eventObj, options, ct) =>",
+            generatedSource);
+    }
+
+    /// <summary>
+    /// Declaring the same event type twice on one class reports NF0504 as a Warning.
+    /// </summary>
+    /// <remarks>
+    /// Warning, not Error, deliberately: the severity split in this generator tracks what gets
+    /// emitted. NF0501/NF0502 add no entry and the class emits no file, so those declarations
+    /// are dead. A duplicate still produces a working registration and only the second
+    /// declaration is inert — NF0503's shape, whose Warning severity was chosen to keep the
+    /// build green. Pinning the severity keeps that reasoning from being reversed silently.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_DuplicateEventType_ReportsNF0504AsWarning()
+    {
+        var source = RelayHandlerSource.Replace(
+            "[FactoryEventHandler<MyEvent>]",
+            "[FactoryEventHandler<MyEvent>]\n    [FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]");
+
+        Assert.NotEqual(RelayHandlerSource, source);
+
+        // runResult.Diagnostics, not the helper's combined array: RunGenerator concatenates
+        // the driver's out-param with runResult.Diagnostics, and generator diagnostics appear
+        // in BOTH, so every diagnostic comes back doubled. Harmless for the Contains/Any
+        // assertions everywhere else in this file, fatal for a count.
+        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        Assert.Equal(DiagnosticSeverity.Warning, duplicate.Severity);
+
+        // The message names the phase that survives, so the consumer knows which declaration
+        // won rather than having to reason about registry dedupe order.
+        Assert.Contains("DispatchPhase.Immediate", duplicate.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// The duplicate's entry is skipped, so one registration is emitted rather than two.
+    /// </summary>
+    /// <remarks>
+    /// This is the half that keeps Warning honest. Left emitting both, a duplicate declaring
+    /// two different phases would emit <c>Immediate</c> then <c>AfterCommit</c> and the
+    /// registry's first-wins dedupe would silently pick one — reintroducing exactly the silent
+    /// phase loss this todo exists to remove, under a diagnostic that says the duplicate is
+    /// "ignored". Skipping the entry makes the emitted code match the message.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_DuplicateEventType_EmitsOneRegistrationNotTwo()
+    {
+        var source = RelayHandlerSource.Replace(
+            "[FactoryEventHandler<MyEvent>]",
+            "[FactoryEventHandler<MyEvent>]\n    [FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]");
+
+        var generatedSource = GeneratedSourceFor(source, "MyHandlers");
+
+        var registrations = generatedSource.Split(["RegisterHandler<TestNamespace.MyEvent>"], StringSplitOptions.None).Length - 1;
+
+        Assert.Equal(1, registrations);
+        Assert.DoesNotContain("DispatchPhase.AfterCommit", generatedSource);
+    }
+
+    /// <summary>
+    /// When the FIRST declaration of an event type fails to produce an entry, the duplicate is
+    /// not reported as one — the original diagnostic repeats instead, exactly as it did before
+    /// NF0504 existed.
+    /// </summary>
+    /// <remarks>
+    /// The duplicate tracker is populated only on success, and this pins why. If it were
+    /// populated on sight of the attribute, this shape would report NF0502 once plus an NF0504
+    /// claiming the handler "is registered at Immediate" — a message that is simply false here,
+    /// since two matching methods means nothing is registered at all. This also holds the
+    /// pre-existing NF0502 emission count steady, which was not something NF0504 was allowed
+    /// to change.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_DuplicateAfterAFailedFirstDeclaration_RepeatsTheOriginalDiagnostic()
+    {
+        var source = @"
+using Neatoo.RemoteFactory;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestNamespace
+{
+    public record MyEvent(int Id) : FactoryEventBase;
+
+    [FactoryEventHandler<MyEvent>]
+    [FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]
+    public static partial class AmbiguousHandlers
+    {
+        internal static Task HandleOne(MyEvent evt) => Task.CompletedTask;
+
+        internal static Task HandleTwo(MyEvent evt) => Task.CompletedTask;
+    }
+}
+";
+        // runResult.Diagnostics — see the note in the NF0504 severity test; the helper's
+        // combined array double-counts, which a count assertion cannot survive.
+        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        Assert.Equal(2, runResult.Diagnostics.Count(d => d.Id == "NF0502"));
+        Assert.Empty(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+    }
+
+    /// <summary>
+    /// Phased emission compiles.
+    /// </summary>
+    /// <remarks>
+    /// Same reasoning as <see cref="RelayHandler_GeneratedOutputCompilesWithoutErrors"/>: relay
+    /// output bypasses <c>NormalizeWhitespace</c> and the renderer swallows throws into a
+    /// comment, so string containment can pass on source that does not compile. A malformed
+    /// phase argument is precisely the shape that would do that.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_PhasedOutput_CompilesWithoutErrors()
+    {
+        var (_, outputCompilation, runResult) = DiagnosticTestHelper.RunGenerator(PhasedRelayHandlerSource);
+
+        Assert.NotNull(runResult.GeneratedTrees.FirstOrDefault(t => t.FilePath.Contains("MixedHandlers")));
+        Assert.Empty(outputCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
     }
 
     #endregion

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
@@ -963,13 +963,9 @@ namespace TestNamespace
 
         Assert.NotEqual(RelayHandlerSource, source);
 
-        // runResult.Diagnostics, not the helper's combined array: RunGenerator concatenates
-        // the driver's out-param with runResult.Diagnostics, and generator diagnostics appear
-        // in BOTH, so every diagnostic comes back doubled. Harmless for the Contains/Any
-        // assertions everywhere else in this file, fatal for a count.
-        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+        var (diagnostics, _, _) = DiagnosticTestHelper.RunGenerator(source);
 
-        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        var duplicate = Assert.Single(diagnostics.Where(d => d.Id == "NF0504"));
         Assert.Equal(DiagnosticSeverity.Warning, duplicate.Severity);
 
         // The message names the phase that survives, so the consumer knows which declaration
@@ -1001,9 +997,9 @@ namespace TestNamespace
 
         Assert.NotEqual(RelayHandlerSource, source);
 
-        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+        var (diagnostics, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
 
-        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        var duplicate = Assert.Single(diagnostics.Where(d => d.Id == "NF0504"));
         var message = duplicate.GetMessage(CultureInfo.InvariantCulture);
         Assert.Contains("DispatchPhase.AfterCommit", message);
         Assert.DoesNotContain("DispatchPhase.Immediate", message);
@@ -1034,9 +1030,9 @@ namespace TestNamespace
             "[FactoryEventHandler<MyEvent>]",
             "[FactoryEventHandler<MyEvent>]\n    [FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]");
 
-        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+        var (diagnostics, _, _) = DiagnosticTestHelper.RunGenerator(source);
 
-        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        var duplicate = Assert.Single(diagnostics.Where(d => d.Id == "NF0504"));
         var span = duplicate.Location.SourceSpan;
 
         Assert.Equal("MyHandlers", source.Substring(span.Start, span.Length));
@@ -1102,12 +1098,10 @@ namespace TestNamespace
     }
 }
 ";
-        // runResult.Diagnostics — see the note in the NF0504 severity test; the helper's
-        // combined array double-counts, which a count assertion cannot survive.
-        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+        var (diagnostics, _, _) = DiagnosticTestHelper.RunGenerator(source);
 
-        Assert.Equal(2, runResult.Diagnostics.Count(d => d.Id == "NF0502"));
-        Assert.Empty(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        Assert.Equal(2, diagnostics.Count(d => d.Id == "NF0502"));
+        Assert.Empty(diagnostics.Where(d => d.Id == "NF0504"));
     }
 
     /// <summary>

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/AssemblyAttributeEmissionTests.cs
@@ -769,14 +769,24 @@ namespace TestNamespace
 {
     public record ProjectionEvent(int Id) : FactoryEventBase;
     public record AtomicEvent(int Id) : FactoryEventBase;
+    public record StagedEvent(int Id) : FactoryEventBase;
+
+    public interface IProjectionPort
+    {
+        Task Send(string message);
+    }
 
     [FactoryEventHandler<ProjectionEvent>(DispatchPhase.AfterCommit)]
     [FactoryEventHandler<AtomicEvent>]
+    [FactoryEventHandler<StagedEvent>(DispatchPhase.AfterFlush)]
     public static partial class MixedHandlers
     {
         internal static Task Project(ProjectionEvent evt) => Task.CompletedTask;
 
         internal static Task Apply(AtomicEvent evt) => Task.CompletedTask;
+
+        internal static Task Stage(StagedEvent evt, [Service] IProjectionPort port, CancellationToken ct)
+            => port.Send(""staged"");
     }
 }
 ";
@@ -846,6 +856,35 @@ namespace TestNamespace
         Assert.Contains(
             "RegisterHandler<TestNamespace.AtomicEvent>(typeof(MixedHandlers), global::Neatoo.RemoteFactory.DispatchPhase.Immediate,",
             generatedSource);
+
+        // AfterFlush has no drain point of its own until PHASE-004, but the member-name lookup
+        // is generic over the enum symbol and this is the only phase not otherwise emitted
+        // anywhere. Its handler also carries [Service] + CancellationToken alongside a phase,
+        // so the phase token and the parameter list are pinned interacting.
+        Assert.Contains(
+            "RegisterHandler<TestNamespace.StagedEvent>(typeof(MixedHandlers), global::Neatoo.RemoteFactory.DispatchPhase.AfterFlush, async (sp, eventObj, options, ct) =>",
+            generatedSource);
+    }
+
+    /// <summary>
+    /// The registration stays inside the server-runtime guard, and the guard's body is the
+    /// registration — asserted in order, not as two independent containments.
+    /// </summary>
+    /// <remarks>
+    /// The relay leg had no <c>IsServerRuntime</c> assertion anywhere in the unit suite before
+    /// this; the only control on it was the CI publish-trimmed gate's absence check, which is
+    /// reasoned from the marker's reachability, runs only on push/PR, and is not in the Step 5
+    /// logs. The guard is what keeps handler bodies and their server-only services out of a
+    /// trimmed client, and this plan's renderer edit is inside the method that emits it.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_PhasedRegistration_StaysInsideTheServerRuntimeGuard()
+    {
+        var generatedSource = GeneratedSourceFor(PhasedRelayHandlerSource, "MixedHandlers");
+
+        Assert.Matches(
+            @"if \(NeatooRuntime\.IsServerRuntime\)\s*\{\s*FactoryEventHandlerRegistry\.RegisterHandler<",
+            generatedSource);
     }
 
     /// <summary>
@@ -881,19 +920,27 @@ namespace TestNamespace
     /// proportion for this plan (todo Discovery Log, 2026-08-15). Silently coercing it to
     /// <c>Immediate</c> would be worse — it would run handlers at a phase nobody declared.
     /// </remarks>
-    [Fact]
-    public void RelayHandler_UndefinedPhaseValue_RendersAsACast()
+    /// <param name="literal">The cast value as written in source.</param>
+    /// <param name="expected">The value as it must appear in the emitted argument.</param>
+    [Theory]
+    [InlineData("99", "99")]
+    // Negative values reach the numeric fallback too, and interpolation would format them with
+    // the BUILD MACHINE's culture. On a culture whose negative sign is not ASCII '-' — sv-SE
+    // resolves to U+2212 under ICU — an unqualified format emits CS1056 into the consumer's
+    // build. This case exists so the invariant formatting has something holding it down.
+    [InlineData("-1", "-1")]
+    public void RelayHandler_UndefinedPhaseValue_RendersAsACast(string literal, string expected)
     {
         var source = PhasedRelayHandlerSource.Replace(
             "[FactoryEventHandler<ProjectionEvent>(DispatchPhase.AfterCommit)]",
-            "[FactoryEventHandler<ProjectionEvent>((DispatchPhase)99)]");
+            $"[FactoryEventHandler<ProjectionEvent>((DispatchPhase)({literal}))]");
 
         Assert.NotEqual(PhasedRelayHandlerSource, source);
 
         var generatedSource = GeneratedSourceFor(source, "MixedHandlers");
 
         Assert.Contains(
-            "typeof(MixedHandlers), (global::Neatoo.RemoteFactory.DispatchPhase)99, async (sp, eventObj, options, ct) =>",
+            $"typeof(MixedHandlers), (global::Neatoo.RemoteFactory.DispatchPhase){expected}, async (sp, eventObj, options, ct) =>",
             generatedSource);
     }
 
@@ -926,8 +973,73 @@ namespace TestNamespace
         Assert.Equal(DiagnosticSeverity.Warning, duplicate.Severity);
 
         // The message names the phase that survives, so the consumer knows which declaration
-        // won rather than having to reason about registry dedupe order.
+        // won rather than having to reason about registry dedupe order. NOTE: the survivor here
+        // is Immediate, which is also what a hardcoded message would say —
+        // RelayHandler_DuplicateEventType_PhasedFirst_... is the test that discriminates.
         Assert.Contains("DispatchPhase.Immediate", duplicate.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// With the PHASED declaration first, the message names <c>AfterCommit</c> and the emitted
+    /// registration is <c>AfterCommit</c> — source order wins, and the message reports it.
+    /// </summary>
+    /// <remarks>
+    /// This is the discriminating half of the pair, and the reason it exists is worth keeping.
+    /// Its sibling stacks unphased-first, so the surviving phase there is <c>Immediate</c> —
+    /// which is also the hardcoded default constant, the value the malformed-argument fallback
+    /// returns, and what a <c>messageFormat</c> with the phase placeholder deleted would print.
+    /// That test stays green against three separate wrong implementations. Both gates on this
+    /// plan flagged it independently; this is the version that can go red, and it pins source
+    /// order at the same time, which nothing else did.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_DuplicateEventType_PhasedFirst_KeepsThatPhaseAndNamesItInTheMessage()
+    {
+        var source = RelayHandlerSource.Replace(
+            "[FactoryEventHandler<MyEvent>]",
+            "[FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]\n    [FactoryEventHandler<MyEvent>]");
+
+        Assert.NotEqual(RelayHandlerSource, source);
+
+        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        var message = duplicate.GetMessage(CultureInfo.InvariantCulture);
+        Assert.Contains("DispatchPhase.AfterCommit", message);
+        Assert.DoesNotContain("DispatchPhase.Immediate", message);
+
+        var generatedSource = runResult.GeneratedTrees
+            .First(t => t.FilePath.Contains("MyHandlers"))
+            .GetText()
+            .ToString();
+
+        Assert.Contains("global::Neatoo.RemoteFactory.DispatchPhase.AfterCommit,", generatedSource);
+        Assert.DoesNotContain("DispatchPhase.Immediate", generatedSource);
+    }
+
+    /// <summary>
+    /// NF0504 is located at the handler class's identifier.
+    /// </summary>
+    /// <remarks>
+    /// Asserted through the source span rather than a line/column pair, so an edit to the
+    /// shared fixture cannot silently turn this into a false red — or, worse, leave it green
+    /// while pointing somewhere else. The class location matches NF0501/NF0502's convention;
+    /// pointing at the redundant attribute itself would serve a consumer with several stacked
+    /// attributes better, and is recorded as a callout rather than done here.
+    /// </remarks>
+    [Fact]
+    public void RelayHandler_DuplicateEventType_DiagnosticIsLocatedAtTheClass()
+    {
+        var source = RelayHandlerSource.Replace(
+            "[FactoryEventHandler<MyEvent>]",
+            "[FactoryEventHandler<MyEvent>]\n    [FactoryEventHandler<MyEvent>(DispatchPhase.AfterCommit)]");
+
+        var (_, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        var duplicate = Assert.Single(runResult.Diagnostics.Where(d => d.Id == "NF0504"));
+        var span = duplicate.Location.SourceSpan;
+
+        Assert.Equal("MyHandlers", source.Substring(span.Start, span.Length));
     }
 
     /// <summary>

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/DiagnosticTestHelperTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/DiagnosticTestHelperTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis;
+using RemoteFactory.UnitTests.TestContainers;
+
+namespace RemoteFactory.UnitTests.FactoryGenerator.Core;
+
+/// <summary>
+/// Guards the diagnostic test harness itself.
+/// </summary>
+/// <remarks>
+/// <c>RunGenerator</c> used to concatenate the driver's out-param with
+/// <c>GetRunResult().Diagnostics</c> — the same set twice — so every diagnostic came back
+/// doubled. No test was red, because no caller counted; the 48 call sites all discard the
+/// diagnostics slot, and the convenience wrappers use <c>Where</c> / <c>First</c> / "any?".
+/// It only surfaced when NF0504's tests asserted <c>Single()</c> and got two.
+/// <para>
+/// A harness that silently doubles its output is worse than one that is merely awkward: it
+/// makes the natural assertion wrong in a way that reads as a product bug. These tests exist
+/// so the next person to touch the helper cannot reintroduce the doubling, and cannot lose
+/// multiplicity while fixing it.
+/// </para>
+/// </remarks>
+public class DiagnosticTestHelperTests
+{
+    /// <summary>
+    /// One duplicate attribute produces exactly one NF0504, not two.
+    /// </summary>
+    [Fact]
+    public void RunGenerator_ReturnsEachDiagnosticOnce()
+    {
+        const string source = @"
+using Neatoo.RemoteFactory;
+using System.Threading.Tasks;
+
+namespace TestNamespace
+{
+    public record HelperEvent(int Id) : FactoryEventBase;
+
+    [FactoryEventHandler<HelperEvent>]
+    [FactoryEventHandler<HelperEvent>(DispatchPhase.AfterCommit)]
+    public static partial class HelperHandlers
+    {
+        internal static Task Handle(HelperEvent evt) => Task.CompletedTask;
+    }
+}
+";
+        var (diagnostics, _, runResult) = DiagnosticTestHelper.RunGenerator(source);
+
+        Assert.Single(diagnostics.Where(d => d.Id == "NF0504"));
+
+        // Same count from the raw run result — i.e. the returned array is one of the two
+        // sources, not a concatenation of both.
+        Assert.Equal(
+            runResult.Diagnostics.Count(d => d.Id == "NF0504"),
+            diagnostics.Count(d => d.Id == "NF0504"));
+    }
+
+    /// <summary>
+    /// A diagnostic genuinely reported twice comes back twice.
+    /// </summary>
+    /// <remarks>
+    /// Two attributes for one event type on a class with two matching handler methods make the
+    /// transform report NF0502 once per attribute, at the same location, with byte-identical
+    /// messages. That count is real signal — collapsing it would turn a reported-twice into a
+    /// reported-once with nothing to notice.
+    /// <para>
+    /// Worth recording what this test measured rather than what was expected of it: a
+    /// <c>Distinct()</c>-based fix for the doubling bug was predicted to break this pin and did
+    /// not. <c>Diagnostic</c> comparison here behaves by identity, and the doubling came from
+    /// concatenating two collections that hold the SAME instances — so identity dedupe removes
+    /// the copies and leaves genuine repeats, which are distinct instances, alone. The helper
+    /// still avoids the concatenation instead, because that correctness depends on an identity
+    /// guarantee nothing in this repo controls. This pin covers both implementations.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void RunGenerator_PreservesGenuinelyRepeatedDiagnostics()
+    {
+        const string source = @"
+using Neatoo.RemoteFactory;
+using System.Threading.Tasks;
+
+namespace TestNamespace
+{
+    public record RepeatEvent(int Id) : FactoryEventBase;
+
+    [FactoryEventHandler<RepeatEvent>]
+    [FactoryEventHandler<RepeatEvent>]
+    public static partial class RepeatHandlers
+    {
+        internal static Task HandleOne(RepeatEvent evt) => Task.CompletedTask;
+
+        internal static Task HandleTwo(RepeatEvent evt) => Task.CompletedTask;
+    }
+}
+";
+        var (diagnostics, _, _) = DiagnosticTestHelper.RunGenerator(source);
+
+        var ambiguous = diagnostics.Where(d => d.Id == "NF0502").ToList();
+
+        Assert.Equal(2, ambiguous.Count);
+
+        // And they really are indistinguishable — which is what makes Distinct() destructive
+        // here rather than harmless.
+        Assert.Equal(ambiguous[0].Location, ambiguous[1].Location);
+        Assert.Equal(ambiguous[0].GetMessage(), ambiguous[1].GetMessage());
+    }
+
+    /// <summary>
+    /// Clean source returns nothing, so neither test above passes by counting noise.
+    /// </summary>
+    [Fact]
+    public void RunGenerator_CleanSource_ReturnsNoRemoteFactoryDiagnostics()
+    {
+        const string source = @"
+using Neatoo.RemoteFactory;
+using System.Threading.Tasks;
+
+namespace TestNamespace
+{
+    public record CleanEvent(int Id) : FactoryEventBase;
+
+    [FactoryEventHandler<CleanEvent>]
+    public static partial class CleanHandlers
+    {
+        internal static Task Handle(CleanEvent evt) => Task.CompletedTask;
+    }
+}
+";
+        var (diagnostics, _, _) = DiagnosticTestHelper.RunGenerator(source);
+
+        Assert.Empty(diagnostics.Where(d => d.Id.StartsWith("NF", StringComparison.Ordinal)));
+    }
+}

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/IncrementalCacheTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/IncrementalCacheTests.cs
@@ -98,7 +98,14 @@ namespace TestNamespace
     // `continue`s WITHOUT adding an entry, leaving Entries empty and every
     // EventHandlerEntry collection unconstructed — the guard would then cover none of
     // them while appearing to. Fixture_ProducesNoDiagnostics pins this.
-    [FactoryEventHandler<OrderPlacedEvent>]
+    //
+    // One phased and one defaulted, so EventHandlerEntry's phase fields are populated on
+    // both paths. Note what this does and does NOT buy: the guard compares transform outputs
+    // across two runs, so a scalar phase field is equal either way — including if the
+    // generator hardcoded Immediate. It would catch a future phase representation that went
+    // COLLECTION-shaped, which is the regression class this fixture exists for. Correctness
+    // of the phase read is pinned in AssemblyAttributeEmissionTests, where it can go red.
+    [FactoryEventHandler<OrderPlacedEvent>(DispatchPhase.AfterCommit)]
     [FactoryEventHandler<OrderShippedEvent>]
     public static partial class OrderHandlers
     {

--- a/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/IncrementalCacheTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/FactoryGenerator/Core/IncrementalCacheTests.cs
@@ -221,6 +221,34 @@ namespace UnrelatedNamespace
                 + $"the caching guard would be vacuous. Emitted: {string.Join(", ", files)}");
     }
 
+    /// <summary>
+    /// Pins that the fixture's phase argument still binds, so the phase fields it claims to
+    /// populate are actually populated.
+    /// </summary>
+    /// <remarks>
+    /// Third fixture-health guard in this file, and the same vacuity class as the other two.
+    /// If the phase argument ever stopped binding — a <c>using</c> dropped, a fixture edit —
+    /// the transform's malformed-argument fallback returns <c>Immediate</c> silently, the
+    /// fixture degrades to two defaulted attributes, and every test here stays green while
+    /// covering less than its comment claims. Nothing else would notice:
+    /// <c>RunGeneratorTracked</c> never inspects the input compilation for CS errors, and
+    /// <see cref="Fixture_ProducesNoDiagnostics"/> filters on <c>NF</c> ids only.
+    /// </remarks>
+    [Fact]
+    public void Fixture_PopulatesThePhaseArgument()
+    {
+        var (_, second) = DiagnosticTestHelper.RunGeneratorTracked(Fixture, UnrelatedAppendix);
+
+        var relaySource = second.GeneratedTrees
+            .FirstOrDefault(t => t.FilePath.EndsWith(".FactoryEventHandler.g.cs"))
+            ?.GetText()
+            ?.ToString();
+
+        Assert.NotNull(relaySource);
+        Assert.Contains("DispatchPhase.AfterCommit", relaySource);
+        Assert.Contains("DispatchPhase.Immediate", relaySource);
+    }
+
     [Fact]
     public void Fixture_ExercisesEveryPipelineBranch()
     {

--- a/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseRegistrationTests.cs
+++ b/src/Tests/RemoteFactory.UnitTests/Internal/FactoryEventPhaseRegistrationTests.cs
@@ -64,10 +64,13 @@ public class FactoryEventPhaseRegistrationTests
     [Fact]
     public void RegisterHandler_SameHandlerClassTwoPhases_KeepsTheFirstRegistration()
     {
-        // Documents the interim semantics of the (eventType, handlerClassType) dedupe key:
-        // a handler class declaring one event at two phases keeps the phase registered
-        // first, for the life of the process. PHASE-002 decides whether the generator
-        // should diagnose this instead.
+        // Documents the semantics of the (eventType, handlerClassType) dedupe key: a handler
+        // class declaring one event at two phases keeps the phase registered first, for the
+        // life of the process. Still reachable through this public API, and still the reason
+        // the generator now reports NF0504 (Warning) and skips the duplicate's entry rather
+        // than emitting two registrations and letting this dedupe pick a winner silently
+        // (PHASE-002). The diagnostic cannot reach a direct RegisterHandler call, so this
+        // behavior stands as pinned.
         FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventD>(typeof(HandlerOne), DispatchPhase.AfterCommit, NoOp);
         FactoryEventHandlerRegistry.RegisterHandler<RegistrationEventD>(typeof(HandlerOne), DispatchPhase.Immediate, NoOp);
 

--- a/src/Tests/RemoteFactory.UnitTests/TestContainers/DiagnosticTestHelper.cs
+++ b/src/Tests/RemoteFactory.UnitTests/TestContainers/DiagnosticTestHelper.cs
@@ -87,10 +87,28 @@ public static class DiagnosticTestHelper
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
         var runResult = driver.GetRunResult();
 
-        // Get diagnostics from the generator run result as well
-        var allDiagnostics = diagnostics.AddRange(runResult.Diagnostics);
-
-        return (allDiagnostics, outputCompilation, runResult);
+        // The driver's out-param already holds every generator diagnostic from this run, and
+        // GetRunResult().Diagnostics holds the same ones — so the AddRange this used to do
+        // returned every diagnostic TWICE. Nothing consumed the count, so nothing was red, but
+        // it silently falsified any count assertion written against this array. Found while
+        // writing NF0504's tests, which asserted Single() and got two.
+        //
+        // Returning one source rather than Distinct()-ing the union, for a narrower reason than
+        // it first appears. Distinct() also works — measured, not assumed: the two collections
+        // hold the SAME Diagnostic instances, so identity dedupe removes the doubling, while
+        // two genuinely repeated diagnostics (a class stacking attributes that each fail the
+        // same way reports NF0502 once per attribute, same location, byte-identical message)
+        // are separate instances and survive. But that correctness rests entirely on the two
+        // collections sharing object identity, which is a Roslyn implementation detail no test
+        // here controls. Not concatenating needs no such assumption.
+        //
+        // Whichever way this is written, multiplicity must be preserved — a genuine repeat is
+        // signal, and DiagnosticTestHelperTests pins it.
+        //
+        // This is the compilation-filtered set — what a consumer's build actually surfaces,
+        // with severity settings and suppressions applied. Callers needing the raw, unfiltered
+        // generator output can still reach RunResult.Diagnostics on the third tuple element.
+        return (diagnostics, outputCompilation, runResult);
     }
 
     private static List<MetadataReference> BuildReferences()


### PR DESCRIPTION
Closes the gap between the phase attribute and the runtime that PHASE-001 and PHASE-003 built. Before this, `[FactoryEventHandler<T>(DispatchPhase.AfterCommit)]` compiled, read as working, and registered at `Immediate` like everything else — the generator read the attribute's type argument and never its constructor arguments.

## What changed

- **Transform** carries the phase as primitives (member name + numeric value). The name is looked up on the enum symbol rather than a hardcoded table, so a phase added to the runtime enum needs no generator change. No `TypedConstant` or `ISymbol` reaches the transform output — either would root a `Compilation` in the incremental cache.
- **Renderer** emits the phase-taking `RegisterHandler` overload for every handler, `global::`-qualified.
- **NF0504 (Warning)** — the same event type declared twice on one class. The duplicate can never carry its own handler, so its entry is skipped and the message names the surviving phase. Closes the duplicate-attribute question PHASE-001 deferred here.
- **`DiagnosticTestHelper`** no longer returns every generator diagnostic twice.

## Decisions worth reviewing

**Duplicate severity is Warning, not Error.** The draft proposed Error; plan review found this project's own precedent pointing the other way — NF0503 chose Warning explicitly to keep the build green for the identical shape. The dividing line in this generator is what gets emitted: NF0501/NF0502 produce no file at all, while a duplicate still produces a working registration. Source that compiles at v1.7.0 keeps compiling, so the arc stays a minor release.

**`AfterFlush` is now consumer-reachable ahead of its drain point.** It already fail-opens at the AfterCommit drain, without the warning PHASE-004's AC-5 promises. Recorded in PHASE-004's inherited section — its acceptance needs an attribute-declared case, not only a hand-registered one.

## Verification

Unit 685, integration 581 (+5 pre-existing skips), Design 86 — all on net9.0 and net10.0, zero failures. Logs in `docs/todos/PHASE-phased-event-dispatch/reviews/`.

Eight red-proofs against deliberate wrong implementations (`reviews/002-redproof.log`), including two that are worth reading:

- Dropping the `global::` qualification turns five unit tests red and leaves integration **fully green** — the bug is behaviorally invisible, which is why it shipped undetected for four releases on the registrar attribute and why the negative pin exists.
- RP-8 **disproved its own premise**. A comment claimed `Distinct()` would collapse genuine repeats; measured false — comparison is by identity, so `Distinct()` would have worked. The fix stands on narrower ground and the comments were corrected. Recorded rather than deleted.

One red-proof attempt also produced a *false green* (the sabotage failed to compile, so tests ran against the correct generator). Build-error counts are now checked in every experiment.

## Gates

- Plan review — CONCERNS, 3 vetoes, all addressed before implementation (`reviews/002-plan-review.md`)
- Test review — no must-cover, 4 should-cover all closed (`reviews/002-test-review.md`)
- Code review — 1 veto closed, 5 callouts fixed (`reviews/002-code-review.md`)

Both gates independently flagged the same unfalsifiable NF0504 message assertion — it was green against three separate wrong implementations. Fixed and red-proofed.

## CI

Deliberately does not run: `build.yml`'s `pull_request` trigger watches `main` only, so the arc → `main` PR is the single CI gate. Per-plan verification is the local full-suite run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)